### PR TITLE
Include .NET build action for pull requests, push to main, and workflow dispatch

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,0 +1,38 @@
+name: .NET Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        solution:
+          - start/GenAiLab.sln
+          - complete/GenAiLab.sln
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ matrix.solution }}
+
+    - name: Build solution
+      run: dotnet build ${{ matrix.solution }} --no-restore --configuration Release
+
+    - name: Run tests
+      run: dotnet test ${{ matrix.solution }} --no-build --verbosity normal


### PR DESCRIPTION
Add a GitHub Actions workflow file for .NET build. Fixes #1

* Create `.github/workflows/dotnet-build.yml` to include .NET build action for pull requests, push to main, and workflow dispatch
* Define a matrix build strategy to build both `/start` and `/complete` solutions
* Add steps for setting up .NET, restoring dependencies, building the solution, and running tests

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet-presentations/build-2025-lab307/pull/3?shareId=221b1824-3349-499c-a0c7-489f03b0ee17).