### PR TITLE
Update dotnet-build.yml for src move

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         solution:
-          - start/GenAiLab.sln
-          - complete/GenAiLab.sln
+          - src/start/GenAiLab.sln
+          - src/complete/GenAiLab.sln
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet-build.yml` file to adjust the paths in the build matrix configuration. 

Workflow configuration updates:

* Updated the `solution` paths in the `matrix` strategy to reflect their correct locations under the `src/` directory (`src/start/GenAiLab.sln` and `src/complete/GenAiLab.sln`).