### PR TITLE
Update docs to match directory structure and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The lab is divided into six modules:
 The repository is structured as follows:
 
 - `/lab`: Contains all the lab instructions and documentation
-- `/src`: Contains the completed solution that you'll build during the lab
+- `/src/start`: Contains the starting code for the lab exercises
+- `/src/complete`: Contains the completed solution after all lab exercises
 
 ## Additional Resources
 

--- a/lab/part3-vector-data.md
+++ b/lab/part3-vector-data.md
@@ -18,7 +18,7 @@ Vector embeddings are numerical representations of text that capture semantic me
 Examine the `SemanticSearch.cs` file to understand how semantic search is implemented:
 
 ```csharp
-namespace MyGenAiLab.Web.Services;
+namespace GenAiLab.Web.Services;
 
 public class SemanticSearch(
     IEmbeddingGenerator<string, Embedding<float>> embedder,
@@ -78,7 +78,7 @@ public record SearchResults(IReadOnlyList<DocumentResult> Results);
 Examine the `SemanticSearchRecord.cs` file:
 
 ```csharp
-namespace MyGenAiLab.Web.Services;
+namespace GenAiLab.Web.Services;
 
 public class SemanticSearchRecord
 {


### PR DESCRIPTION
This pull request updates the structure of the repository and corrects namespace references in the lab documentation. The changes aim to improve clarity for users and ensure consistency in code examples.

### Repository Structure Updates:
* Updated the `README.md` to clarify the structure of the `/src` directory by splitting it into `/src/start` (starting code for lab exercises) and `/src/complete` (completed solution).

### Namespace Corrections:
* Corrected the namespace in `lab/part3-vector-data.md` from `MyGenAiLab.Web.Services` to `GenAiLab.Web.Services` in the `SemanticSearch.cs` file example.
* Corrected the namespace in `lab/part3-vector-data.md` from `MyGenAiLab.Web.Services` to `GenAiLab.Web.Services` in the `SemanticSearchRecord.cs` file example.