### PR TITLE
Update PostgreSQL package references in deployment instructions

### DIFF
--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -14,13 +14,11 @@ The first step in preparing for production is to upgrade our data storage from S
    - Right-click on the `GenAiLab.AppHost` project in Solution Explorer
    - Select "Add" > ".NET Aspire package..."
    - In the package manager that opens (with pre-filtered .NET Aspire packages), search for "Aspire.Hosting.PostgreSQL"
-   - Select the package and click "Install"
-
-   For the `GenAiLab.Web` project:
+   - Select the package and click "Install"   For the `GenAiLab.Web` project:
    - Right-click on the `GenAiLab.Web` project in Solution Explorer
    - Select "Manage NuGet Packages..."
    - Click on the "Browse" tab
-   - Search for "Npgsql.EntityFrameworkCore.PostgreSQL"
+   - Search for "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL"
    - Select the package and click "Install"
 
    **Using Terminal**:   To open the terminal in Visual Studio:
@@ -31,7 +29,7 @@ The first step in preparing for production is to upgrade our data storage from S
 
    ```powershell
    dotnet add GenAiLab.AppHost/GenAiLab.AppHost.csproj package Aspire.Hosting.PostgreSQL
-   dotnet add GenAiLab.Web/GenAiLab.Web.csproj package Npgsql.EntityFrameworkCore.PostgreSQL
+   dotnet add GenAiLab.Web/GenAiLab.Web.csproj package Aspire.Npgsql.EntityFrameworkCore.PostgreSQL
    ```
 
 1. **Update AppHost Program.cs**:


### PR DESCRIPTION
This pull request updates the instructions in `lab/part5-deploy-azure.md` to reflect changes in package names for dependencies related to PostgreSQL integration. The updates ensure consistency in the naming of packages across the document.

Fixes #13 

### Updates to package names:

* Changed the NuGet package name for the `GenAiLab.Web` project from `Npgsql.EntityFrameworkCore.PostgreSQL` to `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` in both the Visual Studio UI instructions and the terminal command. [[1]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L17-R21) [[2]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L34-R32)