### PR TITLE
Update Azure OpenAI lab steps with PDF copy instructions

### DIFF
--- a/lab/part3-azure-openai.md
+++ b/lab/part3-azure-openai.md
@@ -104,23 +104,31 @@ Now you'll update your application's connection string to use Azure OpenAI inste
 
 ## Add new Product PDFs for ingestion
 
-To test the new Azure OpenAI integration, let's add some product PDF files for ingestion:
+To test the new Azure OpenAI integration, let's add the sample product PDF manuals that are included with the lab:
 
 1. In the Solution Explorer, navigate to the `GenAiLab.Web/wwwroot/Data` folder
 
 1. Right-click on the `Data` folder and select "Add" > "Existing Item..."
 
-1. Browse to the location where you have product PDF files (or create some simple PDFs about products)
+1. Browse to the `/lab/manuals` directory in your project folder
 
-1. Select the PDF files and click "Add"
+1. Select all PDF files (Ctrl+A)
 
-For this lab, you can use the following product PDFs:
+1. Click "Add" to copy these files into your project
 
-- Emergency Survival Kit.pdf
-- Hiking Backpack.pdf
-- Rechargeable Flashlight.pdf
-- First Aid Kit.pdf
-- Solar Power Bank.pdf
+These sample manual PDFs include a variety of products such as:
+
+- Example_Backpack.pdf
+- Example_Camera.pdf
+- Example_Camping_Lantern.pdf
+- Example_Double_Hammock.pdf
+- Example_Energy_Bars.pdf
+- Example_Survival_Medkit.pdf
+- Example_Water_Filtration.pdf
+
+And many other product manuals that will provide rich content for testing the AI capabilities.
+
+> **Note**: Ingesting all of these PDFs requires processing a large number of tokens, which would likely exceed the free token limits when using GitHub Models. This is why we're adding these resources after switching to Azure OpenAI, which provides higher token limits and better scaling options. This demonstrates an important consideration when choosing between different AI providers - understanding their resource constraints and cost models is crucial for production applications.
 
 ## Run the application
 

--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -17,7 +17,7 @@ The first step in preparing for production is to upgrade our data storage from S
    - In the package manager that opens (with pre-filtered .NET Aspire packages), search for "Aspire.Hosting.PostgreSQL"
    - Select "9.1.0" for the package version *Important, don't skip this!*
    - Click "Install"
-   
+
      For the `GenAiLab.Web` project:
    - Right-click on the `GenAiLab.Web` project in Solution Explorer
    - Select "Manage NuGet Packages..."
@@ -120,7 +120,7 @@ The first step in preparing for production is to upgrade our data storage from S
 
 1. When prompted with "How do you wnat to initializer your app?", select the default: "Use code in the current directory"
 
-1. After scanning the directory, `azd` prompts you to confirm that it found the correct .NET Aspire _AppHost_ project. Select the **Confirm and continue initializing my app** option.
+1. After scanning the directory, `azd` prompts you to confirm that it found the correct .NET Aspire *AppHost* project. Select the **Confirm and continue initializing my app** option.
 
 1. When prompted to "Enter a unique environment name", enter "mygenailab" or choose something else if you would like.
 
@@ -129,6 +129,7 @@ The first step in preparing for production is to upgrade our data storage from S
    ```powershell
    azd provision
    ```
+
    This command creates all the necessary Azure resources, including:
    - Resource group
    - Container registry
@@ -149,6 +150,7 @@ The first step in preparing for production is to upgrade our data storage from S
    ```powershell
    azd deploy
    ```
+
    This command:
    - Builds your .NET application
    - Creates container images


### PR DESCRIPTION
This pull request includes updates to the lab instructions for integrating Azure OpenAI and deploying to Azure. The most significant changes clarify the process of adding sample product PDFs for testing, improve formatting, and enhance deployment instructions by detailing the provisioning and deployment steps.

### Updates to Azure OpenAI integration:

* Updated instructions to use sample product PDF manuals from the `/lab/manuals` directory, replacing the previous step of creating or finding PDFs manually. This ensures consistency and simplifies the setup process.
* Added a note about token limits and the advantages of using Azure OpenAI for larger-scale processing, highlighting an important consideration for production applications.

Also included some misc markdownlint fixes