### PR TITLE
Improve Azure deployment instructions

### DIFF
--- a/lab/part3-azure-openai.md
+++ b/lab/part3-azure-openai.md
@@ -43,15 +43,14 @@ The same code works whether the `IChatClient` is implemented by GitHub Models, A
 
 To use Azure OpenAI, you need to set up resources in Azure:
 
-1. **Create an Azure OpenAI resource**:
-   - Navigate to the Azure portal (<https://portal.azure.com>)
+1. **Create an Azure OpenAI resource**:   - Navigate to the Azure portal (<https://portal.azure.com>)
    - Click "Create a resource" and search for "Azure OpenAI"
    - Fill in the required details:
-     - Subscription
-     - Resource group
-     - Region
-     - Name
-     - Pricing tier
+     - **Subscription**: Will be pre-selected based on your Azure account
+     - **Resource group**: Select an existing resource group if you are doing this in a lab or create a new one (e.g., "rg-mygenaiapp")
+     - **Resource name**: Choose a unique name for your Azure OpenAI resource (e.g., "mygenaiapp-openai")
+     - **Region**: Select a region close to you (e.g., "East US" or "West Europe"). For Build 2025, we recommend using "West US 3"
+     - **Pricing tier**: Select "Standard" (this is the only option available for Azure OpenAI)
    - Click "Next" on the following screens (leaving the default settings) and then "Create"
 
 ## Deploy the `gpt-4o-mini` model for chat completions
@@ -84,7 +83,7 @@ To connect your application to Azure OpenAI, you need the endpoint and API key:
 1. Open one of your deployments from the above steps if you have closed it
 1. Locate the Endpoint box in the upper left
 1. Copy just the first part of the Endpoint Target URI (it will look like `https://YOUR_RESOURCE_NAME.openai.azure.com/`)
-1. Copy the key (you can use the copy button for this) 
+1. Copy the key (you can use the copy button for this)
 
 ## Update the connection strings
 

--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -139,7 +139,7 @@ The first step in preparing for production is to upgrade our data storage from S
   
 1. When prompted to "Enter a value for the 'azureAISearch' infrastructure secured parameter, copy and past the value from your `secrets.json` file. It will begin with "Endpoint=" and end with your search key. Make sure that you grab your Azure AI Search connection string and not the Azure OpenAI connection string!
 
-1. When prompted to select a loction, select a nearby Azure datacenter.
+1. When prompted to select a location, select "West US 3" for Build 2025 attendees (or another nearby Azure datacenter if you're following this lab outside of the conference).
 
 1. When prompted to "Enter a value for the 'openai' infrastructure secured parameter, copy and past the value from your `secrets.json` file. As before, it will begin with "Endpoint=" and end with your Azure OpenAI key.
 


### PR DESCRIPTION
This pull request updates the Azure setup instructions in the lab documentation to improve clarity and ensure consistency with the Build 2025 conference recommendations. The most important changes include refining the steps for creating an Azure OpenAI resource and specifying the recommended Azure datacenter location.

### Updates to Azure setup instructions:

* **Azure OpenAI resource creation**: Enhanced the instructions to include detailed descriptions for each field, such as specifying the subscription, resource group, resource name, region, and pricing tier. Added recommendations for naming conventions and regions (e.g., "West US 3" for Build 2025 attendees).

* **Azure datacenter location selection**: Updated the instructions to recommend selecting "West US 3" for Build 2025 attendees, while providing flexibility for other users to choose a nearby datacenter.