### PR TITLE
Add prereq and instructions for GitHub Account

### DIFF
--- a/lab/part0-setup.md
+++ b/lab/part0-setup.md
@@ -12,6 +12,7 @@ Before starting the lab, ensure you have:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop) or [Podman](https://podman.io/)
 - .NET AI Web Chatbot template installed
 - .NET 9.0 SDK or later
+- GitHub account (required for GitHub Models access)
 - Azure subscription (optional, but recommended for full experience)
 - GitHub Copilot subscription (optional, but recommended for full experience)
 
@@ -43,7 +44,18 @@ Before starting the lab, ensure you have:
 
    - You should see the help information for the *AI Chat Web App (C#)* displayed.
 
-## Step 2: Clone the Repository
+## Step 2: Create a GitHub Account (if needed)
+
+If you don't already have a GitHub account, follow these steps to create one:
+
+1. **Create a GitHub account:**
+   - Go to [https://github.com/signup](https://github.com/signup)
+   - Enter your email address and create a password
+   - Choose a username
+   - Complete the account creation process by following the on-screen instructions
+   - Verify your email address (GitHub will send you a verification email)
+
+## Step 3: Clone the Repository
 
 Clone the lab repository to get all the necessary files:
 
@@ -54,4 +66,4 @@ cd build-2025-lab307
 
 ## Next Steps
 
-Once your setup is complete, proceed to [Part 1 - Create a Project with AI Web Chat Template](part1-create-project.md).
+Once your setup is complete, proceed to [Part 1 - Create a Project with AI Web Chat Template](part1-create-project.md)

--- a/lab/part1-create-project.md
+++ b/lab/part1-create-project.md
@@ -37,6 +37,8 @@ Create a new project using the AI Web Chat template as follows:
 
 For GitHub Models to work, you need to set up a connection string with a GitHub token:
 
+> **Note:** This step requires a GitHub account. If you don't have one yet, please follow the instructions in [Part 0: Setup](part0-setup.md#step-2-create-a-github-account-if-needed) to create a GitHub account.
+
 1. Create a GitHub token for accessing GitHub Models:
    - Go to [https://github.com/settings/tokens](https://github.com/settings/tokens)
    - Click "Generate new token (classic)"


### PR DESCRIPTION
This pull request updates the lab setup and instructions to include steps for creating and using a GitHub account, which is now required for accessing GitHub Models. The most important changes involve updating the prerequisites, adding a new step for creating a GitHub account, and clarifying dependencies on GitHub in subsequent steps.

### Updates to prerequisites and setup instructions:

* [`lab/part0-setup.md`](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3R15): Added "GitHub account" as a prerequisite for the lab and included a new section, "Step 2: Create a GitHub Account (if needed)," with detailed instructions for creating a GitHub account. The existing step for cloning the repository was renumbered to Step 3. [[1]](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3R15) [[2]](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3L46-R58)

### Clarifications on GitHub dependency:

* [`lab/part1-create-project.md`](diffhunk://#diff-6743b1383f9b9c1d2b2c204680bfa3d2c39542f70f0f25eefb425bf22bf3afc6R40-R41): Added a note to the instructions for setting up a GitHub token, referencing the new GitHub account creation step in Part 0. This ensures users are aware of the dependency on having a GitHub account.

### Minor formatting adjustment:

* [`lab/part0-setup.md`](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3L57-R69): Removed an unnecessary period in the "Next Steps" section for consistency in formatting.