### PR TITLE
Add Markdown linting workflow to validate markdown files

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,34 @@
+name: Markdown Linting
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  markdown-lint:
+    name: Lint Markdown Files
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        
+    - name: Install markdownlint-cli
+      run: npm install -g markdownlint-cli
+      
+    - name: Run markdownlint
+      run: markdownlint '**/*.md' --ignore node_modules


### PR DESCRIPTION
This pull request introduces enhancements to the GitHub Actions workflows, focusing on improving build and linting processes. The key changes include refining the triggers for the `.NET build` workflow and adding a new workflow for Markdown linting.

### Workflow Trigger Enhancements:
* [`.github/workflows/dotnet-build.yml`](diffhunk://#diff-ad500d44fcdc80118f5126903c29ba356c669ce8c155498faed0eb9272137d53R7-R13): Updated the `push` and `pull_request` triggers to include the `paths` filter, ensuring the workflow only runs for changes in the `src` directory.

### New Markdown Linting Workflow:
* [`.github/workflows/markdownlint.yml`](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cR1-R34): Added a new workflow for Markdown linting. It runs on `push` and `pull_request` events targeting Markdown files (`**.md`) and includes steps to set up Node.js, install `markdownlint-cli`, and lint Markdown files while ignoring `node_modules`.