### PR TITLE
Add warnings for Build 2025 lab attendees regarding RG name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,16 @@ The repository is structured as follows:
 - `/src/start`: Contains the starting code for the lab exercises
 - `/src/complete`: Contains the completed solution after all lab exercises
 
-
-## Session Resources 
+## Session Resources
 
 | Resources          | Links                             | Description        |
 |:-------------------|:----------------------------------|:-------------------|
-| Build session page | https://build.microsoft.com/sessions/lab307 | Event session page with downloadable recording, slides, resources, and speaker bio |
-|Microsoft Learn|https://aka.ms/build25/plan/ADAI_DevStartPlan|Official Collection or Plan with skilling resources to learn at your own pace|
-|Microsoft Learn|https://learn.microsoft.com/en-us/dotnet/machine-learning/ai-overview|.NET AI Documentation|
-|Microsoft Learn|https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview|.NET Aspire Documentation|
-|Microsoft Learn|https://learn.microsoft.com/en-us/dotnet/machine-learning/extensions-ai/|Microsoft Extensions for AI Documentation|
-|Microsoft Learn|https://learn.microsoft.com/en-us/azure/ai-services/openai/|Azure OpenAI Documentation|
-
+| Build session page | <https://build.microsoft.com/sessions/lab307> | Event session page |
+|Microsoft Learn|<https://aka.ms/build25/plan/ADAI_DevStartPlan>|AI developer resources|
+|Microsoft Learn|<https://learn.microsoft.com/en-us/dotnet/machine-learning/ai-overview>|.NET AI Documentation|
+|Microsoft Learn|<https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview>|.NET Aspire Documentation|
+|Microsoft Learn|<https://learn.microsoft.com/en-us/dotnet/machine-learning/extensions-ai/>|Extensions for AI Documentation|
+|Microsoft Learn|<https://learn.microsoft.com/en-us/azure/ai-services/openai/>|Azure OpenAI Documentation|
 
 ## License
 

--- a/lab/part0-setup.md
+++ b/lab/part0-setup.md
@@ -19,6 +19,9 @@ Before starting the lab, ensure you have:
 > [!IMPORTANT]
 > If you are completing this in the Build lab session, these prerequisites should already be installed on your virtual machine.
 
+> [!WARNING]
+> For the Build 2025 lab, all Azure resources MUST be created in the "rg-mygenaiapp" resource group. This resource group has already been created in the subscription. When creating new resources via the portal, select this resource group rather than creating a new one. Permissions are restricted to only allow creating resources in this resource group, so missing this will cause resource creation to fail.
+
 ## Step 1: Install Required Tools
 
 1. **Install Visual Studio 2022:**

--- a/lab/part3-azure-openai.md
+++ b/lab/part3-azure-openai.md
@@ -53,6 +53,9 @@ To use Azure OpenAI, you need to set up resources in Azure:
      - **Pricing tier**: Select "Standard" (this is the only option available for Azure OpenAI)
    - Click "Next" on the following screens (leaving the default settings) and then "Create"
 
+> [!WARNING]
+> **FOR BUILD 2025 LAB ATTENDEES**: You MUST select the **"rg-mygenaiapp"** resource group that has already been created for you. Do not create a new resource group. Permissions are restricted to only allow creating resources in this resource group.
+
 ## Deploy the `gpt-4o-mini` model for chat completions
 
 After creating your Azure OpenAI resource, you need to deploy the models:

--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -122,7 +122,10 @@ The first step in preparing for production is to upgrade our data storage from S
 
 1. After scanning the directory, `azd` prompts you to confirm that it found the correct .NET Aspire *AppHost* project. Select the **Confirm and continue initializing my app** option.
 
-1. When prompted to "Enter a unique environment name", enter "mygenailab" or choose something else if you would like.
+1. When prompted to "Enter a unique environment name", enter "mygenaiapp" or choose something else if you would like.
+
+> [!WARNING]
+> **FOR BUILD 2025 LAB ATTENDEES**: You MUST enter exactly **"mygenaiapp"** as your environment name. This is because azd will automatically add the "rg-" prefix when creating the resource group. The lab environment has already been configured with "rg-mygenaiapp" as the resource group, and permissions are restricted to only allow creating resources in this resource group.
 
 1. **Provision Azure resources**:
 
@@ -136,10 +139,16 @@ The first step in preparing for production is to upgrade our data storage from S
    - Container apps environment
    - Container apps for your application
    - Log Analytics workspace
+
+> [!NOTE]
+> When provisioning resources with `azd`, it will automatically create a resource group with the prefix "rg-" added to your environment name (e.g., "rg-mygenaiapp"). For Build 2025 lab attendees, this is why it's essential to use exactly "mygenaiapp" as your environment name.
   
 1. When prompted to "Enter a value for the 'azureAISearch' infrastructure secured parameter, copy and past the value from your `secrets.json` file. It will begin with "Endpoint=" and end with your search key. Make sure that you grab your Azure AI Search connection string and not the Azure OpenAI connection string!
 
 1. When prompted to select a location, select "West US 3" for Build 2025 attendees (or another nearby Azure datacenter if you're following this lab outside of the conference).
+
+> [!WARNING]
+> **FOR BUILD 2025 LAB ATTENDEES**: You MUST select "West US 3" as your location. This region has been pre-configured with the necessary quotas for your lab environment.
 
 1. When prompted to "Enter a value for the 'openai' infrastructure secured parameter, copy and past the value from your `secrets.json` file. As before, it will begin with "Endpoint=" and end with your Azure OpenAI key.
 


### PR DESCRIPTION
This pull request updates the lab instructions to include additional warnings and notes specific to the Build 2025 lab environment. These changes ensure attendees follow the correct configurations and avoid issues caused by restricted permissions or pre-configured settings.

### Build 2025 Lab-Specific Warnings:

* Added a warning in `lab/part0-setup.md` instructing attendees to create all Azure resources in the pre-created "rg-mygenaiapp" resource group, as permissions are restricted to this group.
* Added a similar warning in `lab/part3-azure-openai.md` emphasizing the requirement to select the "rg-mygenaiapp" resource group when setting up Azure OpenAI resources.
* Updated `lab/part5-deploy-azure.md` to require attendees to use "mygenaiapp" as the environment name during `azd` initialization, as this aligns with the pre-configured resource group "rg-mygenaiapp".

### Additional Notes and Region-Specific Instructions:

* Added a note in `lab/part5-deploy-azure.md` explaining that `azd` automatically prefixes the environment name with "rg-" when creating resource groups, reinforcing the importance of using "mygenaiapp".
* Added a warning in `lab/part5-deploy-azure.md` requiring attendees to select "West US 3" as the location, as this region has been pre-configured with the necessary quotas for the lab.