### PR TITLE
Updated /src/complete code so it's ready to be deployed

### DIFF
--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -4,6 +4,9 @@
 
 In this lab, you will learn how to deploy your AI application to Azure using the Azure Developer CLI (`azd`). You'll prepare your application for production, migrate from SQLite to PostgreSQL for better scalability, and deploy your application to Azure Container Apps.
 
+> [!TIP]
+> If you haven't completed the previous steps in the lab or are having trouble with your code, you can use the `/src/complete` folder which already includes all the necessary changes. The complete code has already been updated with the PostgreSQL configuration and external HTTP endpoints setup described in this section. You can skip directly to the "Set Up the Azure Developer CLI" section and deploy that code instead.
+
 ## Prepare for Production: Migrate from SQLite to PostgreSQL
 
 The first step in preparing for production is to upgrade our data storage from SQLite (which is great for development) to PostgreSQL (which is better suited for production workloads).

--- a/src/complete/GenAiLab.AppHost/GenAiLab.AppHost.csproj
+++ b/src/complete/GenAiLab.AppHost/GenAiLab.AppHost.csproj
@@ -10,11 +10,11 @@
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>5fa71442-e079-4644-ba88-00b715396dfc</UserSecretsId>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
     <PackageReference Include="Aspire.Hosting.Qdrant" Version="9.1.0" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="9.3.1-beta.260" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/complete/GenAiLab.AppHost/Program.cs
+++ b/src/complete/GenAiLab.AppHost/Program.cs
@@ -10,8 +10,10 @@ var vectorDB = builder.AddQdrant("vectordb")
     .WithDataVolume()
     .WithLifetime(ContainerLifetime.Persistent);
 
-var ingestionCache = builder.AddSqlite("ingestionCache");
-var productDb = builder.AddSqlite("productDb");
+var postgres = builder.AddPostgres("postgres")
+    .WithLifetime(ContainerLifetime.Persistent);
+var ingestionCache = postgres.AddDatabase("ingestionCache");
+var productDb = postgres.AddDatabase("productDb");
 
 var webApp = builder.AddProject<Projects.GenAiLab_Web>("aichatweb-app");
 webApp.WithReference(openai);
@@ -24,5 +26,6 @@ webApp
 webApp
     .WithReference(productDb)
     .WaitFor(productDb);
+webApp.WithExternalHttpEndpoints();
 
 builder.Build().Run();

--- a/src/complete/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/src/complete/GenAiLab.Web/GenAiLab.Web.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>f7716fa2-dcd4-4fdf-aba2-6b805bd07306</UserSecretsId>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.1.0-preview.1.25121.10" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.4" />
@@ -18,6 +17,7 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="9.1.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.45.0-preview" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/complete/GenAiLab.Web/Program.cs
+++ b/src/complete/GenAiLab.Web/Program.cs
@@ -5,6 +5,7 @@ using GenAiLab.Web.Services;
 using GenAiLab.Web.Services.Ingestion;
 using OpenAI;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
+using Aspire.Npgsql.EntityFrameworkCore.PostgreSQL;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
@@ -22,8 +23,8 @@ builder.AddQdrantClient("vectordb");
 builder.Services.AddSingleton<IVectorStore, QdrantVectorStore>();
 builder.Services.AddScoped<DataIngestor>();
 builder.Services.AddSingleton<SemanticSearch>();
-builder.AddSqliteDbContext<IngestionCacheDbContext>("ingestionCache");
-builder.AddSqliteDbContext<ProductDbContext>("productDb");
+builder.AddNpgsqlDbContext<IngestionCacheDbContext>("ingestionCache");
+builder.AddNpgsqlDbContext<ProductDbContext>("productDb");
 builder.Services.AddScoped<ProductService>();
 
 var app = builder.Build();


### PR DESCRIPTION
This pull request introduces changes to migrate the application from SQLite to PostgreSQL for improved scalability and production readiness. It also includes updates to support external HTTP endpoints and provides guidance for users who may need pre-configured code to proceed with the lab. Below is a summary of the most important changes:

### Migration from SQLite to PostgreSQL:

* [`src/complete/GenAiLab.AppHost/GenAiLab.AppHost.csproj`](diffhunk://#diff-a8182c733fa2757b897817f29572c4f7ff858c517b2cfc0066418184ff5919eaL13-R17): Added a dependency on the `Aspire.Hosting.PostgreSQL` package to enable PostgreSQL support.
* [`src/complete/GenAiLab.AppHost/Program.cs`](diffhunk://#diff-dc0d126a6dae649cbcd827f4e4aab6e05c6f8257585a43617950ac42f7a4473aL13-R16): Replaced SQLite configurations with PostgreSQL configurations using `AddPostgres`, and updated database initialization for `ingestionCache` and `productDb`.
* [`src/complete/GenAiLab.Web/GenAiLab.Web.csproj`](diffhunk://#diff-ffcd8077df705a1540e0a07014ff2ed4d9cfd320cc9268155fc7adcc43d15731R20): Added a dependency on `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` for PostgreSQL integration with Entity Framework Core.
* [`src/complete/GenAiLab.Web/Program.cs`](diffhunk://#diff-32f824b55be4abbcfd2b87d113edf7eb48ed4d5bf7ab5edae5439cb94db408acL25-R27): Updated database context registrations to use PostgreSQL instead of SQLite by replacing `AddSqliteDbContext` with `AddNpgsqlDbContext`.

### Support for external HTTP endpoints:

* [`src/complete/GenAiLab.AppHost/Program.cs`](diffhunk://#diff-dc0d126a6dae649cbcd827f4e4aab6e05c6f8257585a43617950ac42f7a4473aR29): Added `WithExternalHttpEndpoints` to the `webApp` configuration to enable external HTTP endpoint support.

### Documentation update:

* [`lab/part5-deploy-azure.md`](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88R7-R9): Added a tip to guide users to use the pre-configured `/src/complete` folder if they encounter issues, allowing them to skip directly to the deployment steps.