### PR TITLE
Update markdownlint workflow to ignore 'src' directory

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - '**.md'
+      - '!src/**/*.md'
   pull_request:
     branches:
       - main
     paths:
       - '**.md'
+      - '!src/**/*.md'
   workflow_dispatch:
 
 jobs:
@@ -31,4 +33,4 @@ jobs:
       run: npm install -g markdownlint-cli
       
     - name: Run markdownlint
-      run: markdownlint '**/*.md' --ignore node_modules
+      run: markdownlint '**/*.md' --ignore 'node_modules' --ignore 'src'


### PR DESCRIPTION
This pull request updates the Markdown linting workflow to exclude Markdown files in the `src` directory from being linted. The changes ensure that only relevant Markdown files are processed, improving the workflow's efficiency.

Workflow configuration updates:

* [`.github/workflows/markdownlint.yml`](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cR9-R15): Updated the `paths` configuration under both `push` and `pull_request` triggers to exclude files matching the `src/**/*.md` pattern. (`[.github/workflows/markdownlint.ymlR9-R15](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cR9-R15)`)
* [`.github/workflows/markdownlint.yml`](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cL34-R36): Modified the `Run markdownlint` job to add an additional `--ignore 'src'` flag, ensuring that Markdown files in the `src` directory are ignored during linting. (`[.github/workflows/markdownlint.ymlL34-R36](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cL34-R36)`)