### PR TITLE
Remove references to BUILD Lab 307 to prep for repo rename

### DIFF
--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -20,8 +20,6 @@ There are two main objectives:
 
 2. **Azure AI Preferred**: Azure AI setup is significantly simpler than GitHub Models. If Azure AI credentials are available, use them instead of GitHub Models for smoother testing experience.
 
-3. **Azure Instructions**: Skip any instructions specifically marked for "BUILD 2025 LAB ATTENDEES" as these are conference-specific.
-
 4. **Code Inconsistencies**: Some documentation may show code that doesn't match the current template. Focus on what actually gets generated and works, not exact code matches in documentation.
    - Documentation shows `SemanticSearchRecord` but actual code uses `IngestedChunk`
    - Documentation shows `IVectorStore` pattern but actual code uses `VectorStoreCollection`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<p align="center">
-<img src="img/banner.jpg" alt="decorative banner" width="1200"/>
-</p>
-
-# BUILD25 LAB30**Development to Production Pathway** This diagram illustrates the transition path from a local development environment to production deployment. During development, you'll use GitHub Models and a local vector database, which provides a cost-effective environment for experimentation and testing. In production, the application transitions to Azure OpenAI for enterprise-grade AI capabilities, Qdrant for robust vector storage, and Azure Container Apps for a scalable, managed cloud hosting environment. This migration path enables seamless transition while maintaining architectural consistency.*Development to Production Pathway** This diagram illustrates the transition path from a local development environment to production deployment. During development, you'll use GitHub Models and a local vector database, which provides a cost-effective environment for experimentation and testing. In production, the application transitions to Azure OpenAI for enterprise-grade AI capabilities, Qdrant for vector storage and retrieval, and Azure Container Apps for a scalable, managed cloud hosting environment. This migration path enables seamless transition while maintaining architectural consistency. - Building GenAI Apps in C#: AI Templates, GitHub Models, Azure OpenAI & More 🚀
+# .NET AI Workshop
 
 Get up to speed quickly with AI app building in .NET! Explore the new .NET AI project templates integrated with Microsoft Extensions for AI (MEAI), GitHub Models, and vector data stores. Learn how to take advantage of free GitHub Models in development, then deploy with global scale and enterprise support using Azure OpenAI. Gain hands-on experience building cutting-edge intelligent solutions with state-of-the-art frameworks and best practices.
 
@@ -151,7 +147,6 @@ The repository is structured as follows:
 
 | Resources          | Links                             | Description        |
 |:-------------------|:----------------------------------|:-------------------|
-| Build session page | <https://build.microsoft.com/sessions/lab307> | Event session page |
 |Microsoft Learn|<https://aka.ms/build25/plan/ADAI_DevStartPlan>|AI developer resources|
 |Microsoft Learn|<https://learn.microsoft.com/en-us/dotnet/machine-learning/ai-overview>|.NET AI Documentation|
 |Microsoft Learn|<https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview>|.NET Aspire Documentation|

--- a/lab/part0-setup.md
+++ b/lab/part0-setup.md
@@ -1,8 +1,8 @@
 # Part 0: Setup
 
-## In this lab
+## In this workshop
 
-In this lab, you will set up your development environment for building AI applications with .NET. You'll install the required tools and configure your environment to work with the lab materials.
+In this workshop, you will set up your development environment for building AI applications with .NET. You'll install the required tools and configure your environment to work with the workshop materials.
 
 ## Prerequisites
 
@@ -25,13 +25,13 @@ git clone https://github.com/dotnet-presentations/build-2025-lab307.git
 cd build-2025-lab307
 ```
 
-> [!WARNING]
-> For the Build 2025 lab, all Azure resources MUST be created in the "rg-mygenaiapp" resource group. This resource group has already been created in the subscription. When creating new resources via the portal, select this resource group rather than creating a new one. Permissions are restricted to only allow creating resources in this resource group, so missing this will cause resource creation to fail.
+> [!NOTE]
+> When deploying to Azure, you may need to create resources in a specific resource group (e.g., "rg-mygenaiapp"). If you are following this workshop in a managed environment, use the resource group provided by your instructor or organization. Otherwise, you can create your own resource group as needed.
 
 ## Step 1: Install Required Tools
 
 > [!IMPORTANT]
-> If you are completing this in the Build lab session, these prerequisites should already be installed on your virtual machine.
+> If you are using a managed or pre-configured environment, some prerequisites may already be installed for you.
 
 1. **Install Visual Studio 2022:**
    - Download and install Visual Studio 2022 from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)

--- a/lab/part1-create-project.md
+++ b/lab/part1-create-project.md
@@ -1,8 +1,8 @@
 # Create a new project using the AI Web Chat template
 
-## In this lab
+## In this workshop
 
-In this lab, you'll create a new project using the AI Web Chat template in Visual Studio. You'll configure GitHub Models as the AI service provider, set up the connection string, and run and explore the application.
+In this workshop, you'll create a new project using the AI Web Chat template in Visual Studio. You'll configure GitHub Models as the AI service provider, set up the connection string, and run and explore the application.
 
 ## Create the project using Visual Studio
 

--- a/lab/part2-explore-template.md
+++ b/lab/part2-explore-template.md
@@ -1,8 +1,8 @@
 # Explore the Template Code
 
-## In this lab
+## In this workshop
 
-In this lab, you'll explore the code structure of the AI Web Chat template. You'll learn about the different services configured in the .NET Aspire AppHost, understand the application configuration in the Web project, explore how `IChatClient` is configured and used, and dive into Microsoft Extensions for Vector Data.
+In this workshop, you'll explore the code structure of the AI Web Chat template. You'll learn about the different services configured in the .NET Aspire AppHost, understand the application configuration in the Web project, explore how `IChatClient` is configured and used, and dive into Microsoft Extensions for Vector Data.
 
 ## Services in .NET Aspire AppHost Program.cs
 

--- a/lab/part3-azure-openai.md
+++ b/lab/part3-azure-openai.md
@@ -1,8 +1,8 @@
 # Convert from GitHub Models to Azure OpenAI
 
-## In this lab
+## In this workshop
 
-In this lab, you will learn how to migrate your application from using GitHub Models during development to Azure OpenAI for production. You'll understand how the common interfaces in Microsoft Extensions for AI make this migration seamless, create an Azure OpenAI resource, deploy models, and update your application's configuration.
+In this workshop, you will learn how to migrate your application from using GitHub Models during development to Azure OpenAI for production. You'll understand how the common interfaces in Microsoft Extensions for AI make this migration seamless, create an Azure OpenAI resource, deploy models, and update your application's configuration.
 
 > [!TIP]
 > **Azure AI is Often Simpler**: If you have Azure AI credentials available, Azure OpenAI setup is typically simpler than GitHub Models. The configuration requires fewer steps and has better error handling. Consider starting with Azure AI if you have access.
@@ -50,14 +50,13 @@ To use Azure OpenAI, you need to set up resources in Azure:
    - Click "Create a resource" and search for "Azure OpenAI"
    - Fill in the required details:
      - **Subscription**: Will be pre-selected based on your Azure account
-     - **Resource group**: Select an existing resource group if you are doing this in a lab or create a new one (e.g., "rg-mygenaiapp")
-     - **Resource name**: Choose a unique name for your Azure OpenAI resource (e.g., "mygenaiapp-openai")
-     - **Region**: Select a region close to you (e.g., "East US" or "West Europe"). For Build 2025, we recommend using "West US 3"
+     - **Resource group**: Select an existing resource group if you are doing this in a managed environment or create a new one (e.g., "rg-mygenaiapp")
+     - **Region**: Select a region close to you (e.g., "East US" or "West Europe")
      - **Pricing tier**: Select "Standard" (this is the only option available for Azure OpenAI)
    - Click "Next" on the following screens (leaving the default settings) and then "Create"
 
-> [!WARNING]
-> **FOR BUILD 2025 LAB ATTENDEES**: You MUST select the **"rg-mygenaiapp"** resource group that has already been created for you. Do not create a new resource group. Permissions are restricted to only allow creating resources in this resource group.
+> [!NOTE]
+> If you are using a managed environment, use the resource group provided by your instructor or organization. Otherwise, you can create your own resource group as needed.
 
 ## Deploy the `gpt-4o-mini` model for chat completions
 

--- a/lab/part4-products-page.md
+++ b/lab/part4-products-page.md
@@ -1,8 +1,8 @@
 # Write a New Products Page
 
-## In this lab
+## In this workshop
 
-In this lab, you'll enhance your application by creating a Products page that leverages AI to automatically generate product descriptions and categorize items based on their content. This lab demonstrates several key concepts in modern AI application development:
+In this workshop, you'll enhance your application by creating a Products page that leverages AI to automatically generate product descriptions and categorize items based on their content. This workshop demonstrates several key concepts in modern AI application development:
 
 🧩 **What we're building:**
 

--- a/lab/part5-deploy-azure.md
+++ b/lab/part5-deploy-azure.md
@@ -1,8 +1,8 @@
 # Deploy to Azure
 
-## In this lab
+## In this workshop
 
-In this lab, you will learn how to deploy your AI application to Azure using the Azure Developer CLI (`azd`). You'll deploy your PostgreSQL-based application to Azure Container Apps for production use.
+In this workshop, you will learn how to deploy your AI application to Azure using the Azure Developer CLI (`azd`). You'll deploy your PostgreSQL-based application to Azure Container Apps for production use.
 
 > [!TIP]
 > If you haven't completed the previous steps in the lab or are having trouble with your code, you can use the `/src/complete` folder which already includes all the necessary changes. The complete code has already been updated with the PostgreSQL configuration and external HTTP endpoints setup described in this section. You can skip directly to the "Set Up the Azure Developer CLI" section and deploy that code instead.
@@ -56,8 +56,8 @@ In this lab, you will learn how to deploy your AI application to Azure using the
 
 1. When prompted to "Enter a unique environment name", enter "mygenaiapp" or choose something else if you would like.
 
-> [!WARNING]
-> **FOR BUILD 2025 LAB ATTENDEES**: You MUST enter exactly **"mygenaiapp"** as your environment name. This is because azd will automatically add the "rg-" prefix when creating the resource group. The lab environment has already been configured with "rg-mygenaiapp" as the resource group, and permissions are restricted to only allow creating resources in this resource group.
+> [!NOTE]
+> If you are using a managed environment, use the environment name provided by your instructor or organization. Otherwise, you can choose any name you prefer.
 
 1. **Provision Azure resources**:
 
@@ -73,14 +73,11 @@ In this lab, you will learn how to deploy your AI application to Azure using the
    - Log Analytics workspace
 
 > [!NOTE]
-> When provisioning resources with `azd`, it will automatically create a resource group with the prefix "rg-" added to your environment name (e.g., "rg-mygenaiapp"). For Build 2025 lab attendees, this is why it's essential to use exactly "mygenaiapp" as your environment name.
+> When provisioning resources with `azd`, it will automatically create a resource group with the prefix "rg-" added to your environment name (e.g., "rg-mygenaiapp").
   
 1. When prompted to "Enter a value for the 'azureAISearch' infrastructure secured parameter, copy and past the value from your `secrets.json` file. It will begin with "Endpoint=" and end with your search key. Make sure that you grab your Azure AI Search connection string and not the Azure OpenAI connection string!
 
-1. When prompted to select a location, select "West US 3" for Build 2025 attendees (or another nearby Azure datacenter if you're following this lab outside of the conference).
-
-> [!WARNING]
-> **FOR BUILD 2025 LAB ATTENDEES**: You MUST select "West US 3" as your location. This region has been pre-configured with the necessary quotas for your lab environment.
+1. When prompted to select a location, select a region close to you (e.g., "West US 3" or another nearby Azure datacenter).
 
 1. When prompted to "Enter a value for the 'openai' infrastructure secured parameter, copy and past the value from your `secrets.json` file. As before, it will begin with "Endpoint=" and end with your Azure OpenAI key.
 


### PR DESCRIPTION
This pull request updates the `.NET AI Workshop` documentation and materials to generalize instructions, remove event-specific content, and improve clarity. The most important changes include rebranding the materials from "lab" to "workshop," removing references to the Build 2025 event, and updating resource group and deployment instructions to be more flexible for general use.

### General Rebranding and Terminology Updates:
* Replaced "lab" with "workshop" throughout all workshop files to reflect the broader audience and use case (`lab/part0-setup.md`, `lab/part1-create-project.md`, `lab/part2-explore-template.md`, `lab/part3-azure-openai.md`, `lab/part4-products-page.md`, `lab/part5-deploy-azure.md`). [[1]](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3L3-R5) [[2]](diffhunk://#diff-6743b1383f9b9c1d2b2c204680bfa3d2c39542f70f0f25eefb425bf22bf3afc6L3-R5) [[3]](diffhunk://#diff-4dec3e5ac14e46f0a206b31bc37f73900ede951f442f0aab269008d768cd8ff7L3-R5) [[4]](diffhunk://#diff-389c3ba250090390c4869609428ba9de08c9ff0646366c40c045f8e01f8f9a8bL3-R5) [[5]](diffhunk://#diff-d5fe9ca8c72d4bd97d514ac941799b9986b9abffbb8fde68ef8e01be6430c668L3-R5) [[6]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L3-R5)

### Removal of Event-Specific Content:
* Removed Build 2025-specific instructions, such as mandatory resource group names and region selections, replacing them with generalized guidance for managed or self-managed environments (`lab/part0-setup.md`, `lab/part3-azure-openai.md`, `lab/part5-deploy-azure.md`). [[1]](diffhunk://#diff-e8ffdb0a79d877e4c387ed490b9d822729a709af87aaaa8b6bb682820ad26ea3L28-R34) [[2]](diffhunk://#diff-389c3ba250090390c4869609428ba9de08c9ff0646366c40c045f8e01f8f9a8bL53-R59) [[3]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L59-R60) [[4]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L76-R80)
* Deleted references to the Build 2025 session page from the `README.md` file.

### Documentation Improvements:
* Updated the `README.md` file to focus on the `.NET AI Workshop` instead of Build 2025, emphasizing the use of .NET AI templates and Azure OpenAI for scalable AI applications.
* Clarified instructions for Azure resource creation and deployment, allowing more flexibility for users outside of event-specific constraints (`lab/part3-azure-openai.md`, `lab/part5-deploy-azure.md`). [[1]](diffhunk://#diff-389c3ba250090390c4869609428ba9de08c9ff0646366c40c045f8e01f8f9a8bL53-R59) [[2]](diffhunk://#diff-b7b56e4529d2e92c1e2d324eef427fd88678b6f8225f85082481bf9ead99db88L76-R80)

### Other Changes:
* Removed outdated instructions in `.github/prompts/test-workshop.prompt.md` related to Build 2025 attendees.