### PR TITLE
Bump Aspire.Hosting.Qdrant from 13.0.0 to 13.1.1

### DIFF
--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Qdrant" Version="13.0.0" />
+    <PackageReference Include="Aspire.Hosting.Qdrant" Version="13.1.1" />
     <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates Aspire.Hosting.Qdrant from 13.0.0 to 13.1.1 after refreshing the branch on top of the latest main.