### PR TITLE
chore(deps): batch Dependabot version bumps

### DIFF
--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Qdrant" Version="13.1.1" />
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.1" />
+    <PackageReference Include="Aspire.Hosting.Qdrant" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.1-preview.1.25474.6" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
     <PackageReference Include="PdfPig" Version="0.1.13" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.72.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.2.0" />
-    <PackageReference Include="Aspire.Qdrant.Client" Version="13.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Aspire.Qdrant.Client" Version="13.4.6" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.61.0-preview" />
   </ItemGroup>
 

--- a/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />

--- a/Part 5 - Products Page/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 5 - Products Page/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="PdfPig" Version="0.1.14" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="13.1.2" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.61.0-preview" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.13" />
-    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
+++ b/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR supersedes the open Dependabot PRs by applying all of their version bumps on top of the latest `main` in a single change, resolving the inter-PR conflicts that were blocking them.

## Bumps included (17 across 8 project files)

- #439 OpenTelemetry.Instrumentation.Http -> 1.15.1
- #441 OpenTelemetry.Instrumentation.Runtime -> 1.15.1
- #446 ModelContextProtocol -> 1.3.0
- #458 Microsoft.Extensions.Hosting -> 10.0.8
- #468 Microsoft.AspNetCore.Components.QuickGrid -> 9.0.16
- #471 Microsoft.Extensions.VectorData.Abstractions -> 10.6.0
- #476 Microsoft.SemanticKernel.Core -> 1.77.0
- #479 Aspire.Hosting.AppHost -> 13.4.6
- #480 Aspire.Hosting.Qdrant -> 13.4.6
- #481 Aspire.Qdrant.Client -> 13.4.6
- #482 Microsoft.Extensions.AI -> 10.7.0
- #483 Microsoft.Extensions.AI.OpenAI -> 10.7.0
- #484 Microsoft.Extensions.Http.Resilience -> 10.7.0
- #438 OpenTelemetry.Instrumentation.AspNetCore -> 1.15.2
- #488 OpenTelemetry.Exporter.OpenTelemetryProtocol (Part 4/5/6) -> 1.15.3

Note: #392 (PdfPig 0.1.14) was already merged directly.

Closes #438, #439, #441, #446, #458, #468, #471, #476, #479, #480, #481, #482, #483, #484, #488