### PR TITLE
docs: align MCP publishing dependency versions

### DIFF
--- a/Part 9 - MCP Publishing/README.md
+++ b/Part 9 - MCP Publishing/README.md
@@ -88,8 +88,8 @@ For this example, we'll publish the **MyMcpServer** from Part 7. First, update t
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Updates Part 9 - MCP Publishing/README.md so the sample .csproj package references match the currently merged dependency versions:

- Microsoft.Extensions.Hosting -> 10.0.8
- ModelContextProtocol -> 1.3.0

This keeps the publishing guide aligned with the latest Dependabot version bumps.