### PR TITLE
Make Azure AI Foundry the primary AI provider across Parts 1-6 (#492)

### DIFF
--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/AppHost.cs
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.AppHost/AppHost.cs
@@ -3,7 +3,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+// Primary: Azure AI Foundry (Azure OpenAI)
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+// Legacy fallback (GitHub Models, retiring 2026-07-30):
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/Part 2 - Project Creation/README.md
+++ b/Part 2 - Project Creation/README.md
@@ -4,7 +4,7 @@
 
 ## In this workshop
 
-In this workshop, you'll create a new project using the AI Web Chat template in Visual Studio. You'll configure GitHub Models as the AI service provider, set up the connection string, and run and explore the application.
+In this workshop, you'll create a new project using the AI Web Chat template in Visual Studio. You'll configure Azure AI Foundry (Azure OpenAI) as the AI service provider, set up the connection string, and run and explore the application.
 
 ## Create the project using Visual Studio
 
@@ -26,13 +26,15 @@ Create a new project using the AI Web Chat template as follows:
    ![Configure New Project in Visual Studio](../images/vs-configure-new-project.png)
 
 1. Configure AI options:
-   - Select "GitHub Models" for AI service provider
+   - Select "Azure OpenAI" for AI service provider
    - Select "Qdrant" for Vector store
    - Check the box for "Use keyless authentication for Azure services"
    - Check the box for "Use Aspire orchestration"
    - Click "Create"
 
-   > **Alternative: Ollama Option**: If you're using the Ollama development container (see [Development Container Options](../.github/.devcontainer/README.md)), you can select "Ollama" as the AI service provider instead of "GitHub Models". This allows you to work with local AI models without requiring a GitHub account or internet connection.
+   > **Alternative: Ollama Option**: If you're using the Ollama development container (see [Development Container Options](../.github/.devcontainer/README.md)), you can select "Ollama" as the AI service provider instead of "Azure OpenAI". This allows you to work with local AI models without requiring an Azure or GitHub account or internet connection.
+   >
+   > **Legacy: GitHub Models**: GitHub Models is being [retired on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/). You can still select "GitHub Models" as a temporary fallback, but Azure AI Foundry is the recommended provider.
 
    ![Additional Information in Visual Studio](../images/vs-additional-information.png)
 
@@ -57,17 +59,17 @@ If you prefer to use the command line, you can create the same project using the
 3. Create the project using the `dotnet new` command with the appropriate parameters:
 
    ```powershell
-   dotnet new aichatweb --name GenAiLab --Framework net9.0 --provider githubmodels --vector-store qdrant --aspire true
+   dotnet new aichatweb --name GenAiLab --Framework net9.0 --provider azureopenai --vector-store qdrant --aspire true
    ```
 
    This command creates a new AI Chat Web App with:
    - Project name: `GenAiLab`
    - Framework: `.NET 9.0`
-   - AI service provider: `GitHub Models`
+   - AI service provider: `Azure OpenAI (Azure AI Foundry)`
    - Vector store: `Qdrant`
    - .NET Aspire orchestration: `enabled`
 
-   > **Alternative: Ollama Option**: If you're using the Ollama development container, you can replace `--provider githubmodels` with `--provider ollama` to use local AI models instead.
+   > **Alternative: Ollama Option**: If you're using the Ollama development container, you can replace `--provider azureopenai` with `--provider ollama` to use local AI models instead. GitHub Models (`--provider githubmodels`) remains available as a legacy fallback until its [retirement on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/).
 
 4. Navigate into the project directory:
 
@@ -136,11 +138,39 @@ If you prefer to use the command line, you can update all packages using the `do
    dotnet build
    ```
 
-## Set the GitHub Models connection string
+## Set the Azure AI Foundry connection string
 
-For GitHub Models to work, you need to set up a connection string with a GitHub token:
+Your application uses **Azure AI Foundry** (Azure OpenAI models) as its AI provider. You'll need an Azure OpenAI resource with the `gpt-4o-mini` (chat) and `text-embedding-3-small` (embeddings) models deployed.
 
-> **Note:** This step requires a GitHub account. If you don't have one yet, please follow the instructions in [Part 1: Setup](../Part%201%20-%20Setup/README.md#step-2-create-a-github-account-if-needed) to create a GitHub account.
+> **Note:** The detailed steps to create an Azure OpenAI resource and deploy these two models are covered in [Part 4: Azure AI Foundry](../Part%204%20-%20Azure%20OpenAI/README.md#create-the-azure-openai-resource). If your instructor provided a pre-provisioned resource, use the endpoint and key they gave you.
+
+1. Deploy (or obtain access to) an Azure OpenAI resource with:
+   - `gpt-4o-mini` deployed for chat completions
+   - `text-embedding-3-small` deployed for embeddings
+
+1. Copy your resource **endpoint** (it looks like `https://YOUR_RESOURCE_NAME.openai.azure.com/`) and an **API key**.
+
+1. In the Solution Explorer, right-click on the `GenAiLab.AppHost` project and select "Manage User Secrets".
+
+1. In the `secrets.json` file that opens, add the following connection string:
+
+   ```json
+   {
+      "ConnectionStrings:openai": "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+   }
+   ```
+
+   Replace `YOUR_RESOURCE_NAME` and `YOUR_API_KEY` with your Azure OpenAI resource values.
+
+1. Save the `secrets.json` file.
+
+<details>
+<summary><strong>Legacy fallback: GitHub Models</strong> (retiring July 30, 2026)</summary>
+
+> [!WARNING]
+> GitHub Models is being [fully retired on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/), with scheduled brownouts on July 16 and July 23. Use it only if you don't yet have Azure access, and expect it to stop working after retirement.
+
+If you need to use GitHub Models as a temporary fallback (and created the project with `--provider githubmodels`):
 
 1. Create a GitHub token for accessing GitHub Models:
    - Go to [https://github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)
@@ -150,21 +180,17 @@ For GitHub Models to work, you need to set up a connection string with a GitHub 
    - Click "Generate token" at the bottom of the page
    - Copy the generated token (you won't be able to see it again)
 
-   > **Note**: For additional guidance on configuring GitHub Models access, see the [Microsoft documentation quickstart](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/ai-templates?tabs=dotnet-cli%2Cconfigure-visual-studio%2Cconfigure-visual-studio-aspire&pivots=github-models#configure-access-to-github-models).
-
-1. In the Solution Explorer, right-click on the `GenAiLab.AppHost` project and select "Manage User Secrets"
-
-1. In the `secrets.json` file that opens, add the following connection string:
+1. In the `GenAiLab.AppHost` user secrets, add this connection string instead:
 
    ```json
    {
-      "ConnectionStrings:openai": "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+      "ConnectionStrings:openai": "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
    }
    ```
 
-   Replace `YOUR-API-KEY` with the GitHub token you created in step 1.
+   Replace `YOUR-GITHUB-TOKEN` with the token you created.
 
-1. Save the `secrets.json` file.
+</details>
 
 ## Run the application
 
@@ -221,7 +247,7 @@ Let's test the AI functionality of the application:
 
 - How to create a new project using the AI Web Chat template in Visual Studio
 - How to update NuGet packages in a solution to get the latest AI and Aspire components
-- How to configure GitHub Models as the AI service provider
+- How to configure Azure AI Foundry (Azure OpenAI) as the AI service provider
 - How to set up the connection string for AI services
 - How to use .NET Aspire to orchestrate multiple services
 - How to interact with an AI-powered chat application
@@ -256,15 +282,15 @@ dotnet restore
 dotnet build
 ```
 
-#### Issue: GitHub Models Connection Fails
+#### Issue: Azure OpenAI Connection Fails
 
 **Problem**: Authentication errors or "unauthorized" messages when testing chat.
 
 **Solution**:
 
-1. Verify your GitHub token has the correct permissions
-2. Check that the token is correctly placed in `secrets.json`
-3. Ensure the connection string format is correct: `"Endpoint=https://models.inference.ai.azure.com;Key=YOUR_TOKEN"`
+1. Verify your Azure OpenAI (Azure AI Foundry) resource has `gpt-4o-mini` and `text-embedding-3-small` deployed
+2. Check that the endpoint and key are correctly placed in `secrets.json`
+3. Ensure the connection string format is correct: `"Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"`
 
 #### Issue: Template Not Found
 

--- a/Part 3 - Template Exploration/README.md
+++ b/Part 3 - Template Exploration/README.md
@@ -67,7 +67,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+// Primary: Azure AI Foundry (Azure OpenAI)
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+// Legacy fallback (GitHub Models, retiring 2026-07-30):
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.AppHost/AppHost.cs
+++ b/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.AppHost/AppHost.cs
@@ -3,7 +3,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+// Primary: Azure AI Foundry (Azure OpenAI)
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+// Legacy fallback (GitHub Models, retiring 2026-07-30):
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/Part 5 - Products Page/GenAiLab/GenAiLab.AppHost/AppHost.cs
+++ b/Part 5 - Products Page/GenAiLab/GenAiLab.AppHost/AppHost.cs
@@ -3,7 +3,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+// Primary: Azure AI Foundry (Azure OpenAI)
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+// Legacy fallback (GitHub Models, retiring 2026-07-30):
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/Part 5 - Products Page/README.md
+++ b/Part 5 - Products Page/README.md
@@ -14,7 +14,7 @@ In this workshop, you'll enhance your application by creating a Products page th
 
 🔍 **Key technical concepts you'll learn:**
 
-- **AI Service Abstraction**: Work with `IChatClient` interface that allows you to interact with AI models without being tied to a specific provider (like GitHub Models or Azure OpenAI)
+- **AI Service Abstraction**: Work with `IChatClient` interface that allows you to interact with AI models without being tied to a specific provider (like Azure OpenAI or GitHub Models)
   
 - **Vector Database as Primary Store**: Learn how vector databases can serve as both storage and search engine, eliminating the need for separate databases
 
@@ -703,7 +703,7 @@ Your Products feature now works entirely with Qdrant as the data store:
 
 1. **Simplified Architecture**: No PostgreSQL setup required - everything uses Qdrant collections
 
-1. **AI Integration**: The service uses your configured AI provider (GitHub Models or Azure OpenAI) to process content and generate structured product information
+1. **AI Integration**: The service uses your configured AI provider (Azure OpenAI or GitHub Models) to process content and generate structured product information
 
 ## Troubleshooting
 

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/AppHost.cs
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/AppHost.cs
@@ -3,7 +3,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+// Primary: Azure AI Foundry (Azure OpenAI)
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
+// Legacy fallback (GitHub Models, retiring 2026-07-30):
+//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET AI Workshop
 
-Get up to speed quickly with AI app building in .NET! Explore the new .NET AI project templates integrated with Microsoft Extensions for AI (MEAI), GitHub Models, and vector data stores. Learn how to take advantage of free GitHub Models in development, then deploy with global scale and enterprise support using Azure OpenAI. Gain hands-on experience building cutting-edge intelligent solutions with state-of-the-art frameworks and best practices.
+Get up to speed quickly with AI app building in .NET! Explore the new .NET AI project templates integrated with Microsoft Extensions for AI (MEAI), Azure AI Foundry, and vector data stores. Learn how to build with Azure AI Foundry (Azure OpenAI) models for both development and production, with GitHub Models and local models (Foundry Local / Ollama) available as fallbacks. Gain hands-on experience building cutting-edge intelligent solutions with state-of-the-art frameworks and best practices.
 
 ## Prerequisites
 
@@ -10,8 +10,8 @@ Get up to speed quickly with AI app building in .NET! Explore the new .NET AI pr
 - .NET AI Web Chatbot template installed (instructions in Part 1 - Setup)
 - .NET 9.0 SDK or later
 - Docker Desktop or Podman (required for .NET Aspire orchestration)
-- GitHub account (required for GitHub Models access)
-- Azure OpenAI subscription (optional, but recommended for full experience)
+- Azure subscription with access to Azure AI Foundry (Azure OpenAI) — the primary AI provider
+- GitHub account (optional; GitHub Models is a legacy fallback [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/))
 
 ### Model Context Protocol (Parts 7-9)
 
@@ -32,7 +32,7 @@ The lab consists of a series of hands-on exercises where you'll build an AI-powe
 - 🤖 **AI Chatbot**: A conversational interface that can answer questions about products
 - 📋 **Product Catalog**: AI-generated product descriptions and categories
 - 🔍 **Semantic Search**: Vector-based search using document embeddings
-- 🔌 **Integration with GitHub Models and Azure OpenAI**: Use free models for development and enterprise-grade models for production
+- 🔌 **Integration with Azure AI Foundry**: Use Azure OpenAI models for development and production, with GitHub Models and local models (Foundry Local / Ollama) as fallbacks
 
 ## What We're Building
 
@@ -45,7 +45,7 @@ flowchart TD
     User([User]) <--> WebApp[Web Application<br>Blazor UI]
     WebApp <--> VectorDB[(Vector Database<br>Qdrant)]
     WebApp <--> AIChatService[AI Chat Service<br>Microsoft.Extensions.AI]
-    AIChatService <--> AIProvider[AI Provider<br>GitHub Models / Azure OpenAI]
+    AIChatService <--> AIProvider[AI Provider<br>Azure AI Foundry / GitHub Models legacy]
     
     subgraph Data Flow
         PDFs[Product PDFs] --> Ingestion[Data Ingestion]
@@ -66,7 +66,7 @@ flowchart TD
     class PDFs,Ingestion,Embeddings dataflow
 ```
 
-**Architecture Overview** This diagram illustrates the component relationships in our outdoor gear application. The Blazor web application connects with three key components: a vector database for storing embeddings, an AI chat service powered by Microsoft.Extensions.AI, and a product database. The AI functionality is provided by either GitHub Models (for development) or Azure OpenAI (for production). The data flow shows how product PDFs are ingested, transformed into embeddings, and stored in the vector database to enable contextual AI responses.
+**Architecture Overview** This diagram illustrates the component relationships in our outdoor gear application. The Blazor web application connects with three key components: a vector database for storing embeddings, an AI chat service powered by Microsoft.Extensions.AI, and a product database. The AI functionality is provided by Azure AI Foundry (Azure OpenAI models), with GitHub Models available as a legacy fallback (retiring July 30, 2026). The data flow shows how product PDFs are ingested, transformed into embeddings, and stored in the vector database to enable contextual AI responses.
 
 ### Component Interaction 🔄
 
@@ -95,7 +95,7 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    Dev[Development<br>GitHub Models] --> Prod[Production<br>Azure OpenAI]
+    Dev[Development<br>Azure AI Foundry] --> Prod[Production<br>Azure AI Foundry]
     Local[Local Vector DB<br>Qdrant] --> Cloud[Cloud Vector DB<br>Qdrant]
     
     subgraph Development Environment


### PR DESCRIPTION
## Summary

Closes #492.

GitHub Models is [fully retired on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/) (brownouts July 16 & 23), so it can no longer be the default provider for the July 27 workshop. This PR makes **Azure AI Foundry (Azure OpenAI)** the primary provider across Parts 1–6 and demotes GitHub Models to a clearly-labeled legacy fallback.

Because the app already uses `AddAzureOpenAIClient` (and the `IChatClient` / `IEmbeddingGenerator` abstractions), this is a documentation + connection-string change — no application code rewrite.

## Changes

- **Part 2** — Azure AI Foundry is now the primary path:
  - Visual Studio flow selects **"Azure OpenAI"**; CLI uses `--provider azureopenai`
  - New **"Set the Azure AI Foundry connection string"** section (endpoint/key + `gpt-4o-mini` / `text-embedding-3-small`), linking to the Part 4 deployment steps
  - GitHub Models moved into a collapsible **legacy fallback** block with a retirement `[!WARNING]`
  - Updated "What You've Learned" and the connection-troubleshooting entry to Azure
- **Part 3** — exploration code comment shows the Azure endpoint as primary, GitHub Models as legacy
- **Root README** — architecture diagram node, "Development → Production" flow, intro, lab-overview bullet, and prerequisites all lead with Azure AI Foundry (GitHub Models labeled legacy/retiring)
- **Part 5** — provider mentions reordered (Azure first)
- **Sample `AppHost.cs` (Parts 2, 4, 5, 6)** — user-secrets comment shows the Azure connection string as primary with a GitHub Models legacy note

## Verification

- ✅ Part 2 solution builds (0 warnings, 0 errors)
- ✅ No errors in edited `.cs` files
- ✅ Parts 5–6 functionally unchanged (comment-only code edits)

## Scope notes

Left for their own milestone issues to keep this PR focused:
- Pre-workshop Azure setup checklist → #493
- Retirement banners in Part 1 → #494
- Reframing Part 4 into alternative/local providers → #495

> Follow-up: Part 2 currently links **forward** to Part 4 for resource/model deployment. Once #493 (pre-work checklist) lands, that reference should point at the pre-work section instead.
