### PR TITLE
Use gpt-4.1-mini instead of deprecated gpt-4o-mini in sample projects

### DIFF
--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/Program.cs
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/Program.cs
@@ -9,7 +9,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/Part 2 - Project Creation/README.md
+++ b/Part 2 - Project Creation/README.md
@@ -140,12 +140,12 @@ If you prefer to use the command line, you can update all packages using the `do
 
 ## Set the Azure AI Foundry connection string
 
-Your application uses **Azure AI Foundry** (Azure OpenAI models) as its AI provider. You'll need an Azure OpenAI resource with the `gpt-4o-mini` (chat) and `text-embedding-3-small` (embeddings) models deployed.
+Your application uses **Azure AI Foundry** (Azure OpenAI models) as its AI provider. You'll need an Azure OpenAI resource with the `gpt-4.1-mini` (chat) and `text-embedding-3-small` (embeddings) models deployed.
 
 > **Note:** The detailed steps to create an Azure OpenAI resource and deploy these two models are covered in [Part 4: Azure AI Foundry](../Part%204%20-%20Azure%20OpenAI/README.md#create-the-azure-openai-resource). If your instructor provided a pre-provisioned resource, use the endpoint and key they gave you.
 
 1. Deploy (or obtain access to) an Azure OpenAI resource with:
-   - `gpt-4o-mini` deployed for chat completions
+   - `gpt-4.1-mini` deployed for chat completions
    - `text-embedding-3-small` deployed for embeddings
 
 1. Copy your resource **endpoint** (it looks like `https://YOUR_RESOURCE_NAME.openai.azure.com/`) and an **API key**.
@@ -288,7 +288,7 @@ dotnet build
 
 **Solution**:
 
-1. Verify your Azure OpenAI (Azure AI Foundry) resource has `gpt-4o-mini` and `text-embedding-3-small` deployed
+1. Verify your Azure OpenAI (Azure AI Foundry) resource has `gpt-4.1-mini` and `text-embedding-3-small` deployed
 2. Check that the endpoint and key are correctly placed in `secrets.json`
 3. Ensure the connection string format is correct: `"Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"`
 

--- a/Part 3 - Template Exploration/README.md
+++ b/Part 3 - Template Exploration/README.md
@@ -108,7 +108,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());
@@ -155,7 +155,7 @@ Key components in the Web Program.cs:
 1. **Service Registration**: Setting up Razor components, service defaults, etc.
 1. **Azure OpenAI Setup**:
    - Adding Azure OpenAI client with connection string reference
-   - Configuring a chat client with the "gpt-4o-mini" model
+   - Configuring a chat client with the "gpt-4.1-mini" model
    - Setting up an embedding generator with "text-embedding-3-small" model
 1. **Qdrant Client**: Connecting to the Qdrant vector database
 1. **Vector Collection Services**: Registering collections for ingested chunks and documents directly in the vector database
@@ -171,7 +171,7 @@ The `IChatClient` interface is a key part of Microsoft Extensions for AI. Let's 
 ```csharp
 // Configuration in Program.cs
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());
@@ -269,7 +269,7 @@ Function invocation is enabled when configuring the chat client:
 ```csharp
 // From Program.cs
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()  // This enables the LLM to call functions
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.Web/Program.cs
+++ b/Part 4 - Azure OpenAI/GenAiLab/GenAiLab.Web/Program.cs
@@ -9,7 +9,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/Part 4 - Azure OpenAI/README.md
+++ b/Part 4 - Azure OpenAI/README.md
@@ -68,7 +68,7 @@ To use Azure OpenAI, you need to set up resources in Azure:
 > [!NOTE]
 > If you are using a managed environment, use the resource group provided by your instructor or organization. Otherwise, you can create your own resource group as needed.
 
-## Deploy the `gpt-4o-mini` model for chat completions
+## Deploy the `gpt-4.1-mini` model for chat completions
 
 After creating your Azure OpenAI resource, you need to deploy the models:
 
@@ -76,8 +76,8 @@ After creating your Azure OpenAI resource, you need to deploy the models:
 1. Select "Deployments" from the left menu
 1. Click "+ Deploy model" button
 1. Select the "Deploy base model" option
-1. Select the model "gpt-4o-mini" for chat completions (you can use the search filter to narrow the list down)
-1. Leave the default deployment name and type values ("gpt-4o-mini" and Global Standard)
+1. Select the model "gpt-4.1-mini" for chat completions (you can use the search filter to narrow the list down)
+1. Leave the default deployment name and type values ("gpt-4.1-mini" and Global Standard)
 1. Click "Deploy"
 
 ## Deploy the `text-embedding-3-small` model for embeddings
@@ -210,7 +210,7 @@ dotnet build
 
 **Solution**:
 
-1. Verify both models are deployed: `gpt-4o-mini` and `text-embedding-3-small`
+1. Verify both models are deployed: `gpt-4.1-mini` and `text-embedding-3-small`
 2. Check deployment names match exactly (case-sensitive)
 3. Ensure the Azure OpenAI resource is in the correct region
 4. Verify the endpoint URL format: `https://YOUR_RESOURCE_NAME.openai.azure.com/`

--- a/Part 5 - Products Page/GenAiLab/GenAiLab.Web/Program.cs
+++ b/Part 5 - Products Page/GenAiLab/GenAiLab.Web/Program.cs
@@ -10,7 +10,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/Part 5 - Products Page/README.md
+++ b/Part 5 - Products Page/README.md
@@ -631,7 +631,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.Web/Program.cs
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.Web/Program.cs
@@ -10,7 +10,7 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-4.1-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());


### PR DESCRIPTION
## Summary

Replaces the deprecated **`gpt-4o-mini`** chat model with **`gpt-4.1-mini`** across the sample projects and instructional docs. Follow-up to the Azure AI Foundry primary provider work (#492).

## Why

Verified against the [Azure AI Foundry model retirement schedule](https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule) on 2026-07-02:

- **`gpt-4o-mini` (2024-07-18)** is **Deprecated** → **new subscriptions cannot create new deployments**, and it **retires 2026-10-01**. This blocks new attendees from running the workshop on a fresh Foundry resource.
- **`gpt-4.1-mini`** is Microsoft's official GA replacement (same cheap/fast tier).
- **`text-embedding-3-small`** is unchanged — still GA (retires 2027-04-15).

## Changes

- `GenAiLab.Web/Program.cs` in **Parts 2, 4, 5, 6**: `AddChatClient("gpt-4.1-mini")`
- Instructional docs updated: **Part 2, Part 3, Part 4, Part 5** READMEs (deployment steps, code listings, troubleshooting)
- Historical test report under `docs/testing/` intentionally left unchanged

## Verification

- ✅ Part 2 and Part 6 solutions build (0 warnings, 0 errors)
- ✅ Diff is exactly 16 line changes, all `gpt-4o-mini` → `gpt-4.1-mini` (no other edits)

> Note: the deeper workshop rewrite (milestone #1) supersedes these sample projects later; this small PR keeps the **current** repo working for new subscriptions in the meantime.
