### PR TITLE
Part 2: hands-on console chat app (#499)

### DIFF
--- a/Part 2 - Build Chat App/ChatApp/ChatApp.csproj
+++ b/Part 2 - Build Chat App/ChatApp/ChatApp.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>314f834f-7582-4948-a3be-b64a80c0efbe</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/Part 2 - Build Chat App/ChatApp/Program.cs
+++ b/Part 2 - Build Chat App/ChatApp/Program.cs
@@ -1,0 +1,112 @@
+﻿// =============================================================================
+// Part 2 - Build a Chat App (hands-on, code-first)
+// =============================================================================
+// In this part you build a console chat app from scratch so you understand what
+// the templates generate for you later. You will learn, by writing the code:
+//
+//   1. Secrets-first configuration   (never hardcode keys)
+//   2. Creating an IChatClient        (the core Microsoft.Extensions.AI abstraction)
+//   3. A chat loop with history       (multi-turn conversations)
+//   4. Streaming responses            (token-by-token output)
+//   5. A middleware pipeline          (add logging without touching your app code)
+//
+// Adapted with thanks from Steve Sanderson's dotnet-ai-workshop
+// (https://github.com/SteveSandersonMS/dotnet-ai-workshop).
+// =============================================================================
+
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+// -----------------------------------------------------------------------------
+// 1. Secrets-first configuration
+// -----------------------------------------------------------------------------
+// Endpoint, key, and model name come from user-secrets, NOT source code.
+// Before running, set them once (values are stored outside the repo):
+//
+//   dotnet user-secrets set "AzureOpenAI:Endpoint" "https://YOUR-RESOURCE.openai.azure.com/"
+//   dotnet user-secrets set "AzureOpenAI:Key" "YOUR-KEY"
+//   dotnet user-secrets set "AzureOpenAI:ChatModel" "gpt-4.1-mini"
+//
+var config = new ConfigurationBuilder()
+    .AddUserSecrets<Program>()
+    .Build();
+
+string endpoint = config["AzureOpenAI:Endpoint"]
+    ?? throw new InvalidOperationException(
+        "Missing 'AzureOpenAI:Endpoint'. Run: dotnet user-secrets set \"AzureOpenAI:Endpoint\" \"https://YOUR-RESOURCE.openai.azure.com/\"");
+string key = config["AzureOpenAI:Key"]
+    ?? throw new InvalidOperationException(
+        "Missing 'AzureOpenAI:Key'. Run: dotnet user-secrets set \"AzureOpenAI:Key\" \"YOUR-KEY\"");
+string chatModel = config["AzureOpenAI:ChatModel"] ?? "gpt-4.1-mini";
+
+// -----------------------------------------------------------------------------
+// 2. Create an IChatClient
+// -----------------------------------------------------------------------------
+// AzureOpenAIClient is the provider-specific SDK client. We immediately adapt it
+// to IChatClient - the provider-agnostic Microsoft.Extensions.AI abstraction.
+// Every provider (Azure OpenAI, OpenAI, Ollama, Foundry Local, ...) gives you the
+// same IChatClient, so the rest of your app never changes when you switch models.
+//
+// 5. A middleware pipeline
+//    .AsBuilder() lets us wrap the client with cross-cutting behavior. Here we add
+//    logging - every request/response is logged without changing our app code.
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+    builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+
+IChatClient chatClient = new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(key))
+    .GetChatClient(chatModel)
+    .AsIChatClient()
+    .AsBuilder()
+    .UseLogging(loggerFactory)
+    .Build();
+
+// -----------------------------------------------------------------------------
+// 3. A chat loop with history
+// -----------------------------------------------------------------------------
+// We keep every message in a list so the model has the full conversation context
+// on each turn. The system message sets the assistant's behavior.
+var history = new List<ChatMessage>
+{
+    new(ChatRole.System, "You are a helpful, concise assistant for a .NET workshop.")
+};
+
+Console.WriteLine("Chat app ready. Type a message (or 'exit' to quit).");
+Console.WriteLine();
+
+while (true)
+{
+    Console.Write("You: ");
+    string? input = Console.ReadLine();
+
+    if (string.IsNullOrWhiteSpace(input) ||
+        input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
+        break;
+    }
+
+    history.Add(new ChatMessage(ChatRole.User, input));
+
+    // ---------------------------------------------------------------------
+    // 4. Streaming responses
+    // ---------------------------------------------------------------------
+    // GetStreamingResponseAsync yields the answer token-by-token so the user
+    // sees output immediately. We accumulate the text to add it back to history.
+    Console.Write("Assistant: ");
+    var assistantText = new System.Text.StringBuilder();
+
+    await foreach (ChatResponseUpdate update in chatClient.GetStreamingResponseAsync(history))
+    {
+        Console.Write(update.Text);
+        assistantText.Append(update.Text);
+    }
+
+    Console.WriteLine();
+    Console.WriteLine();
+
+    history.Add(new ChatMessage(ChatRole.Assistant, assistantText.ToString()));
+}
+
+Console.WriteLine("Goodbye!");

--- a/Part 2 - Build Chat App/README.md
+++ b/Part 2 - Build Chat App/README.md
@@ -1,0 +1,146 @@
+# Part 2: Build a Chat App (hands-on, code-first)
+
+In this part you build a console chat application **from scratch**. Instead of
+starting with a template that hides the details, you write the code yourself so
+you understand exactly how a .NET app talks to an AI model. In later parts you
+will add retrieval (RAG) by hand, and *then* see the template that generates all
+of this for you.
+
+> Adapted with thanks from [Steve Sanderson's dotnet-ai-workshop](https://github.com/SteveSandersonMS/dotnet-ai-workshop).
+
+## What you will learn
+
+1. **Secrets-first configuration** – keep API keys out of source code
+2. **`IChatClient`** – the core Microsoft.Extensions.AI abstraction
+3. **A chat loop with history** – multi-turn conversations
+4. **Streaming responses** – token-by-token output
+5. **A middleware pipeline** – add logging without touching your app code
+
+## Prerequisites
+
+- .NET 10 SDK
+- An Azure AI Foundry resource with a **`gpt-4.1-mini`** chat model deployed
+  (see [Part 1 - Setup](../Part%201%20-%20Setup/README.md))
+
+> [!CAUTION]
+> Never hardcode endpoints or API keys in source code. This project uses
+> [user-secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets)
+> so your credentials stay out of the repository.
+
+## Step 1: Create the console project
+
+```bash
+dotnet new console -n ChatApp
+cd ChatApp
+```
+
+## Step 2: Add the packages
+
+```bash
+dotnet add package Microsoft.Extensions.AI
+dotnet add package Microsoft.Extensions.AI.OpenAI --prerelease
+dotnet add package Azure.AI.OpenAI
+dotnet add package Microsoft.Extensions.Configuration.UserSecrets
+dotnet add package Microsoft.Extensions.Logging.Console
+```
+
+| Package | Why |
+| --- | --- |
+| `Microsoft.Extensions.AI` | Provider-agnostic AI abstractions (`IChatClient`) |
+| `Microsoft.Extensions.AI.OpenAI` | Adapts the OpenAI/Azure client to `IChatClient` |
+| `Azure.AI.OpenAI` | The Azure OpenAI SDK client |
+| `Microsoft.Extensions.Configuration.UserSecrets` | Read secrets from outside the repo |
+| `Microsoft.Extensions.Logging.Console` | Console logging for the middleware demo |
+
+## Step 3: Store your credentials
+
+Initialize user-secrets, then set your endpoint, key, and model. Get these from
+the Azure AI Foundry portal (**https://ai.azure.com**).
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "AzureOpenAI:Endpoint" "https://YOUR-RESOURCE.openai.azure.com/"
+dotnet user-secrets set "AzureOpenAI:Key" "YOUR-KEY"
+dotnet user-secrets set "AzureOpenAI:ChatModel" "gpt-4.1-mini"
+```
+
+## Step 4: Write the code
+
+Replace the contents of `Program.cs` with the code in
+[ChatApp/Program.cs](ChatApp/Program.cs). Work through it section by section:
+
+### Configuration (secrets-first)
+
+`ConfigurationBuilder().AddUserSecrets<Program>()` reads the values you set in
+Step 3. If a required value is missing, the app throws a clear error telling you
+which secret to set — no silent failures, no keys in code.
+
+### Create an `IChatClient`
+
+```csharp
+IChatClient chatClient = new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(key))
+    .GetChatClient(chatModel)
+    .AsIChatClient();
+```
+
+`AzureOpenAIClient` is the provider-specific SDK. `.AsIChatClient()` adapts it to
+`IChatClient`, the abstraction the rest of your app uses. Because every provider
+(Azure OpenAI, OpenAI, Ollama, Foundry Local, …) surfaces the same `IChatClient`,
+you can swap models later without changing your app logic.
+
+### A chat loop with history
+
+The conversation lives in a `List<ChatMessage>`. Each turn you add the user's
+message, send the **whole list** to the model (so it has full context), then add
+the assistant's reply. The first message is a `ChatRole.System` prompt that sets
+the assistant's behavior.
+
+### Streaming responses
+
+```csharp
+await foreach (ChatResponseUpdate update in chatClient.GetStreamingResponseAsync(history))
+{
+    Console.Write(update.Text);
+}
+```
+
+`GetStreamingResponseAsync` yields the answer token-by-token so the user sees
+output immediately instead of waiting for the full response.
+
+### A middleware pipeline
+
+```csharp
+IChatClient chatClient = /* ... */
+    .AsIChatClient()
+    .AsBuilder()
+    .UseLogging(loggerFactory)
+    .Build();
+```
+
+`.AsBuilder()` lets you wrap the client with cross-cutting behavior. `UseLogging`
+logs every request and response — and you added it **without changing any of your
+chat-loop code**. This same pattern is how you'll later add function calling,
+caching, and telemetry.
+
+## Step 5: Run it
+
+```bash
+dotnet run
+```
+
+```
+Chat app ready. Type a message (or 'exit' to quit).
+
+You: Give me one tip for learning .NET
+Assistant: Build small projects end-to-end...
+
+You: exit
+Goodbye!
+```
+
+## What's next
+
+In **Part 3** you'll extend this app with **retrieval-augmented generation
+(RAG)** — by hand — so you understand how embeddings and vector search feed
+context to the model. Only after that do you meet the template that wires it all
+up for you.


### PR DESCRIPTION
## Summary

Adds the new **Part 2: Build a Chat App** — a hands-on, code-first console app that attendees build from scratch before ever seeing a template. Resolves #499.

This is the first part of the workshop rewrite.

## What's included

- **`Part 2 - Build Chat App/ChatApp/`** — a `net10.0` console project
  - Secrets-first configuration (user-secrets; no hardcoded keys)
  - `IChatClient` created from `AzureOpenAIClient` via `.AsIChatClient()`
  - Chat loop with conversation history
  - Streaming responses (`GetStreamingResponseAsync`)
  - A middleware pipeline (`.AsBuilder().UseLogging(...)`)
- **`Part 2 - Build Chat App/README.md`** — step-by-step walkthrough

## Teaching flow

Attendees write the code themselves to learn the fundamentals, then meet the
template later (Part 4). RAG is added by hand in Part 3.

## Models & provider

- Provider: **Azure AI Foundry** (Azure OpenAI)
- Chat model: **`gpt-4.1-mini`**

## Validation

- ✅ Builds clean against `net10.0` (`dotnet build -c Release`, 0 warnings, 0 errors)
- ⏳ Runtime validation against a live Azure AI Foundry resource is deferred to the E2E test pass (#504)

## Notes

- `bin/` and `obj/` are gitignored — only source is committed.
- Adapted with attribution from [Steve Sanderson's dotnet-ai-workshop](https://github.com/SteveSandersonMS/dotnet-ai-workshop).
