### PR TITLE
Part 3: hands-on RAG console app (#500)

### DIFF
--- a/Part 3 - Add RAG/README.md
+++ b/Part 3 - Add RAG/README.md
@@ -1,0 +1,139 @@
+# Part 3: Add RAG by hand (console)
+
+In Part 2 you built a chat app. The problem: the model only knows what it was
+trained on. Ask it about *your* product, *your* policies, or anything private and
+it will guess. **Retrieval-Augmented Generation (RAG)** fixes that by retrieving
+relevant text and injecting it into the prompt.
+
+In this part you build a complete RAG loop **by hand** — no vector database, no
+framework magic. When you meet the template in Part 4, you'll recognize every
+piece because you wrote it yourself.
+
+> Adapted with thanks from [Steve Sanderson's dotnet-ai-workshop](https://github.com/SteveSandersonMS/dotnet-ai-workshop) (chapters 2, 3, and 6).
+
+## What you will build
+
+```
+question ─▶ embed ─▶ cosine search over stored chunks ─▶ top-k context
+                                                              │
+document ─▶ chunk ─▶ embed ─▶ store (in-memory list) ─────────┘
+                                                              ▼
+                              augment system prompt ─▶ chat model ─▶ grounded answer
+```
+
+1. **`IEmbeddingGenerator`** — turn text into vectors
+2. **Chunk** the document into retrievable pieces
+3. **Embed + store** the chunks in an in-memory list
+4. **Cosine similarity search** — naive top-k retrieval, written by hand
+5. **Augment the prompt** with the retrieved context, then answer
+
+## Prerequisites
+
+- Completed [Part 2](../Part%202%20-%20Build%20Chat%20App/README.md)
+- An Azure AI Foundry resource with **`gpt-4.1-mini`** *and*
+  **`text-embedding-3-small`** deployed (see [Part 1 - Setup](../Part%201%20-%20Setup/README.md))
+
+## Step 1: Start from the Part 2 project
+
+Copy your Part 2 `ChatApp` (or the [provided project](RagChatApp)) and add one
+package for embeddings — everything else is already there.
+
+The embedding model needs one extra secret:
+
+```bash
+dotnet user-secrets set "AzureOpenAI:EmbeddingModel" "text-embedding-3-small"
+```
+
+## Step 2: Create an embedding generator
+
+The **same** `AzureOpenAIClient` gives you both a chat client and an embedding
+generator — two abstractions over one resource:
+
+```csharp
+IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator =
+    azureClient.GetEmbeddingClient(embeddingModel).AsIEmbeddingGenerator();
+```
+
+An embedding is just an array of floats. Texts with **similar meaning** produce
+vectors pointing in **similar directions** — that's what lets us search by meaning
+instead of by keyword.
+
+## Step 3: Chunk, embed, and store
+
+Split the document into paragraph-sized chunks, embed them all in one call, and
+keep the `(text, vector)` pairs in a plain `List`:
+
+```csharp
+GeneratedEmbeddings<Embedding<float>> embeddings =
+    await embeddingGenerator.GenerateAsync(chunks);
+
+var store = new List<(string Text, ReadOnlyMemory<float> Vector)>();
+for (int i = 0; i < chunks.Length; i++)
+    store.Add((chunks[i], embeddings[i].Vector));
+```
+
+> This is deliberately naive. The list doesn't persist between runs and it won't
+> scale past a few thousand chunks — which is exactly the motivation for the real
+> vector store in Part 4.
+
+## Step 4: Cosine similarity search (by hand)
+
+For each question, embed it with the **same** generator, then rank every stored
+chunk and take the top matches:
+
+```csharp
+var topChunks = store
+    .Select(item => (item.Text, Score: CosineSimilarity(questionVector.Span, item.Vector.Span)))
+    .OrderByDescending(x => x.Score)
+    .Take(topK)
+    .Select(x => x.Text)
+    .ToArray();
+```
+
+Cosine similarity is just `dot(a, b) / (|a| * |b|)` — a value from -1 to 1. See
+`CosineSimilarity` in [RagChatApp/Program.cs](RagChatApp/Program.cs).
+
+## Step 5: Augment the prompt, then answer
+
+Rebuild the system message each turn with the retrieved context, and tell the
+model to answer **only** from it:
+
+```csharp
+var systemPrompt = new ChatMessage(ChatRole.System,
+    "Answer using ONLY the context below. If the answer isn't in the context, say you don't know.\n\n" +
+    $"Context:\n{context}");
+```
+
+Then send `systemPrompt + history + question` to the same streaming chat loop from
+Part 2.
+
+## Step 6: See the difference
+
+Run it and ask something only the document knows:
+
+```bash
+dotnet run
+```
+
+```
+You: How do I dry the boots?
+Assistant: Air-dry them away from direct heat. Never place them on a radiator,
+as that damages the waterproof membrane.
+
+You: What is the warranty?
+Assistant: A 2-year limited warranty covering manufacturing defects...
+
+You: Who won the 2022 World Cup?
+Assistant: I don't know — that isn't in the provided context.
+```
+
+The last answer is the point: the assistant is now **grounded**. It answers from
+your document and declines when the answer isn't there.
+
+## What's next
+
+Your knowledge base lives in memory, so it's rebuilt on every run and can't scale.
+In **Part 4** you'll scaffold the **aichatweb template** and see how it solves
+exactly these problems — a real vector store (Qdrant), a document ingestion
+pipeline, and semantic search — using the same `IChatClient` and
+`IEmbeddingGenerator` abstractions you just used by hand.

--- a/Part 3 - Add RAG/RagChatApp/Program.cs
+++ b/Part 3 - Add RAG/RagChatApp/Program.cs
@@ -1,0 +1,179 @@
+﻿// =============================================================================
+// Part 3 - Add RAG by hand (console)
+// =============================================================================
+// This continues the Part 2 chat app. Now we ground the model in a document it
+// has never seen, by building a Retrieval-Augmented Generation (RAG) loop BY HAND:
+//
+//   1. IEmbeddingGenerator      (turn text into vectors)
+//   2. Chunk the document       (split into retrievable pieces)
+//   3. Embed + store            (an in-memory list - no vector database)
+//   4. Cosine similarity search (naive top-k retrieval, written by hand)
+//   5. Augment the prompt        (inject retrieved context, then answer)
+//
+// Theme: the same swappable-abstraction idea from Part 2 (swap the chat provider)
+// now applies to embeddings and vector stores. In Part 4 the template will do all
+// of this for you - and you'll understand every moving part because you built it.
+//
+// Adapted with thanks from Steve Sanderson's dotnet-ai-workshop
+// (https://github.com/SteveSandersonMS/dotnet-ai-workshop), chapters 2, 3, and 6.
+// =============================================================================
+
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+
+// -----------------------------------------------------------------------------
+// 0. Secrets-first configuration (same pattern as Part 2)
+// -----------------------------------------------------------------------------
+//   dotnet user-secrets set "AzureOpenAI:Endpoint" "https://YOUR-RESOURCE.openai.azure.com/"
+//   dotnet user-secrets set "AzureOpenAI:Key" "YOUR-KEY"
+//   dotnet user-secrets set "AzureOpenAI:ChatModel" "gpt-4.1-mini"
+//   dotnet user-secrets set "AzureOpenAI:EmbeddingModel" "text-embedding-3-small"
+var config = new ConfigurationBuilder()
+    .AddUserSecrets<Program>()
+    .Build();
+
+string endpoint = config["AzureOpenAI:Endpoint"]
+    ?? throw new InvalidOperationException(
+        "Missing 'AzureOpenAI:Endpoint'. Run: dotnet user-secrets set \"AzureOpenAI:Endpoint\" \"https://YOUR-RESOURCE.openai.azure.com/\"");
+string key = config["AzureOpenAI:Key"]
+    ?? throw new InvalidOperationException(
+        "Missing 'AzureOpenAI:Key'. Run: dotnet user-secrets set \"AzureOpenAI:Key\" \"YOUR-KEY\"");
+string chatModel = config["AzureOpenAI:ChatModel"] ?? "gpt-4.1-mini";
+string embeddingModel = config["AzureOpenAI:EmbeddingModel"] ?? "text-embedding-3-small";
+
+// One Azure client, two abstractions: a chat client AND an embedding generator.
+var azureClient = new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(key));
+
+IChatClient chatClient = azureClient.GetChatClient(chatModel).AsIChatClient();
+
+// -----------------------------------------------------------------------------
+// 1. IEmbeddingGenerator
+// -----------------------------------------------------------------------------
+// An embedding turns text into a vector (an array of floats). Texts with similar
+// meaning produce vectors that point in similar directions - that's what lets us
+// search by meaning instead of by keyword.
+IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator =
+    azureClient.GetEmbeddingClient(embeddingModel).AsIEmbeddingGenerator();
+
+// -----------------------------------------------------------------------------
+// 2. Chunk the document
+// -----------------------------------------------------------------------------
+// We split the document into paragraph-sized chunks. Real systems use smarter
+// chunking, but paragraphs are enough to see RAG work. Each chunk must be small
+// enough to embed meaningfully yet large enough to carry a complete idea.
+string docPath = Path.Combine(AppContext.BaseDirectory, "sample-docs", "contoso-trailblazer-3000.md");
+string document = await File.ReadAllTextAsync(docPath);
+
+string[] chunks = document
+    .Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    .Where(c => c.Length > 0)
+    .ToArray();
+
+// -----------------------------------------------------------------------------
+// 3. Embed + store (in-memory - no vector database)
+// -----------------------------------------------------------------------------
+// We embed every chunk once at startup and keep the vectors in a plain list.
+// This is deliberately naive: it doesn't persist and it won't scale - which is
+// exactly the motivation for the real vector store you'll meet in Part 4.
+Console.WriteLine($"Embedding {chunks.Length} chunks from the product guide...");
+
+GeneratedEmbeddings<Embedding<float>> embeddings =
+    await embeddingGenerator.GenerateAsync(chunks);
+
+var store = new List<(string Text, ReadOnlyMemory<float> Vector)>();
+for (int i = 0; i < chunks.Length; i++)
+{
+    store.Add((chunks[i], embeddings[i].Vector));
+}
+
+Console.WriteLine("Knowledge base ready. Ask about the Contoso TrailBlazer 3000 boots.");
+Console.WriteLine("(Type 'exit' to quit.)");
+Console.WriteLine();
+
+// -----------------------------------------------------------------------------
+// The chat loop - now grounded in the document
+// -----------------------------------------------------------------------------
+var history = new List<ChatMessage>();
+
+while (true)
+{
+    Console.Write("You: ");
+    string? input = Console.ReadLine();
+
+    if (string.IsNullOrWhiteSpace(input) ||
+        input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
+        break;
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Cosine similarity search (written by hand)
+    // -------------------------------------------------------------------------
+    // Embed the question with the SAME generator, then rank every stored chunk by
+    // cosine similarity and take the top matches. This is the heart of retrieval.
+    ReadOnlyMemory<float> questionVector =
+        (await embeddingGenerator.GenerateAsync(input)).Vector;
+
+    const int topK = 3;
+    var topChunks = store
+        .Select(item => (item.Text, Score: CosineSimilarity(questionVector.Span, item.Vector.Span)))
+        .OrderByDescending(x => x.Score)
+        .Take(topK)
+        .Select(x => x.Text)
+        .ToArray();
+
+    // -------------------------------------------------------------------------
+    // 5. Augment the prompt, then answer
+    // -------------------------------------------------------------------------
+    // We rebuild the system message every turn with the freshly retrieved context
+    // and instruct the model to answer ONLY from it. That grounding is what turns
+    // a general chat model into a document-aware assistant.
+    string context = string.Join("\n\n---\n\n", topChunks);
+    var systemPrompt = new ChatMessage(ChatRole.System,
+        "You are a product support assistant. Answer the user's question using ONLY " +
+        "the context below. If the answer isn't in the context, say you don't know.\n\n" +
+        $"Context:\n{context}");
+
+    // Send: system prompt (with context) + the running conversation + this question.
+    var messages = new List<ChatMessage> { systemPrompt };
+    messages.AddRange(history);
+    messages.Add(new ChatMessage(ChatRole.User, input));
+
+    Console.Write("Assistant: ");
+    var answer = new System.Text.StringBuilder();
+    await foreach (ChatResponseUpdate update in chatClient.GetStreamingResponseAsync(messages))
+    {
+        Console.Write(update.Text);
+        answer.Append(update.Text);
+    }
+    Console.WriteLine();
+    Console.WriteLine();
+
+    // Keep the conversation going (history holds the user/assistant turns only;
+    // the context is re-retrieved and re-injected fresh each turn).
+    history.Add(new ChatMessage(ChatRole.User, input));
+    history.Add(new ChatMessage(ChatRole.Assistant, answer.ToString()));
+}
+
+Console.WriteLine("Goodbye!");
+
+// -----------------------------------------------------------------------------
+// Naive cosine similarity: dot(a, b) / (|a| * |b|).
+// Returns a value from -1 (opposite) to 1 (identical direction).
+// -----------------------------------------------------------------------------
+static float CosineSimilarity(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+{
+    float dot = 0f, magA = 0f, magB = 0f;
+    for (int i = 0; i < a.Length; i++)
+    {
+        dot += a[i] * b[i];
+        magA += a[i] * a[i];
+        magB += b[i] * b[i];
+    }
+
+    return magA == 0f || magB == 0f
+        ? 0f
+        : dot / (MathF.Sqrt(magA) * MathF.Sqrt(magB));
+}

--- a/Part 3 - Add RAG/RagChatApp/RagChatApp.csproj
+++ b/Part 3 - Add RAG/RagChatApp/RagChatApp.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>3f5950d7-15fc-4315-bc97-8223d81cf9fc</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Copy the sample document to the output directory so the app can read it at runtime. -->
+    <None Include="sample-docs\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/Part 3 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
+++ b/Part 3 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
@@ -1,0 +1,33 @@
+# Contoso TrailBlazer 3000 Hiking Boots — Product Guide
+
+## Overview
+
+The Contoso TrailBlazer 3000 is a waterproof hiking boot designed for multi-day
+backcountry trips. It was released in March 2026 and replaces the TrailBlazer 2000.
+
+## Specifications
+
+- Weight: 1.2 kg per pair (size 42)
+- Waterproof membrane: ContosoDry 4-layer
+- Sole: VibraGrip X2 with 6 mm lugs
+- Upper: recycled nubuck leather and ripstop nylon
+- Temperature range: -10 °C to 30 °C
+- Available sizes: EU 36–48
+
+## Care instructions
+
+Clean the boots with lukewarm water and a soft brush. Do not machine wash. Reapply
+ContosoDry waterproofing spray every 3 months of regular use. Air-dry away from
+direct heat; never place the boots on a radiator, as this damages the membrane.
+
+## Warranty
+
+The TrailBlazer 3000 includes a 2-year limited warranty covering manufacturing
+defects. The warranty does not cover normal wear of the sole or damage from
+improper drying. To make a claim, contact support@contoso.example with your order
+number.
+
+## Return policy
+
+Unworn boots may be returned within 60 days for a full refund. Worn boots can be
+exchanged within 30 days if there is a manufacturing defect.


### PR DESCRIPTION
## Summary

Adds the new **Part 3: Add RAG by hand** — extends the Part 2 console app with a complete, hand-written Retrieval-Augmented Generation loop and **no vector database**. Resolves #500.

Second hands-on part of the workshop rewrite.

## What's included

- **`Part 3 - Add RAG/RagChatApp/`** — a `net10.0` console project
  - `IEmbeddingGenerator` from the same `AzureOpenAIClient` (two abstractions, one resource)
  - Paragraph chunking of a sample document
  - Embed + store in an in-memory `List` (no vector DB)
  - Hand-written **cosine similarity** search + top-k retrieval
  - System-prompt augmentation with retrieved context, then the streaming chat loop from Part 2
  - Sample product doc (`sample-docs/contoso-trailblazer-3000.md`), copied to output
- **`Part 3 - Add RAG/README.md`** — step-by-step walkthrough with a data-flow diagram

## Teaching flow

Reinforces the swappable-abstraction theme: Part 2 swapped the chat provider, Part 3 shows the same idea for embeddings and vector stores. The in-memory store is deliberately naive to motivate the real vector store revealed in Part 4.

## Models & provider

- Provider: **Azure AI Foundry** (Azure OpenAI)
- Chat: **`gpt-4.1-mini`** · Embeddings: **`text-embedding-3-small`**

## Validation

- ✅ Builds clean against `net10.0` (`dotnet build -c Release`, 0 warnings, 0 errors)
- ⏳ Runtime validation against a live Azure AI Foundry resource is deferred to the E2E test pass (#504)

## Notes

- `bin/` and `obj/` are gitignored — only source is committed.
- Adapted with attribution from [Steve Sanderson's dotnet-ai-workshop](https://github.com/SteveSandersonMS/dotnet-ai-workshop) (chapters 2, 3, 6).
