### PR TITLE
Add GitHub Models retirement banners and legacy labeling (#494)

### DIFF
--- a/.github/.devcontainer/README.md
+++ b/.github/.devcontainer/README.md
@@ -18,7 +18,7 @@ This workshop provides two development container configurations to suit differen
 
 **Use this if you:**
 
-- Have a GitHub account for GitHub Models
+- Have a GitHub account for GitHub Models (legacy fallback, [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/) — prefer Azure AI Foundry)
 - Plan to use Azure OpenAI
 - Want to follow the workshop as designed
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -157,7 +157,7 @@ dotnet new mcpserver --help
 - **.NET 9**: AI Web Chat applications with Blazor and .NET Aspire
 - **.NET 8**: MCP server applications  
 - **Microsoft Extensions for AI**: Core AI integration libraries
-- **GitHub Models**: Free AI models for development
+- **GitHub Models**: Legacy dev-only provider, retiring July 30, 2026 — use Azure AI Foundry (Azure OpenAI) instead
 - **Azure OpenAI**: Enterprise-grade AI models for production
 - **Qdrant**: Vector database for embeddings and semantic search
 - **Docker**: Container orchestration for vector databases

--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "/^dotnet --version; Write-Output '--- SDKs ---'; dotnet --list-sdks; Write-Output '--- CI workflow files ---'; Get-ChildItem \\.github/workflows -File \\| Select-Object Name$/": {
+            "approve": true,
+            "matchCommandLine": true
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "chat.tools.terminal.autoApprove": {
-        "/^dotnet --version; Write-Output '--- SDKs ---'; dotnet --list-sdks; Write-Output '--- CI workflow files ---'; Get-ChildItem \\.github/workflows -File \\| Select-Object Name$/": {
-            "approve": true,
-            "matchCommandLine": true
-        }
-    }
-}

--- a/Part 1 - Setup/README.md
+++ b/Part 1 - Setup/README.md
@@ -6,6 +6,9 @@
 
 In this workshop, you will set up your development environment for building AI applications with .NET. You'll install the required tools and configure your environment to work with the workshop materials.
 
+> [!IMPORTANT]
+> **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Set up **Azure AI Foundry (Azure OpenAI)** as your primary provider; the GitHub account below is only for the legacy fallback.
+
 ## Prerequisites
 
 Before starting, ensure you have:

--- a/Part 2 - Build Chat App/README.md
+++ b/Part 2 - Build Chat App/README.md
@@ -55,7 +55,7 @@ dotnet add package Microsoft.Extensions.Logging.Console
 ## Step 3: Store your credentials
 
 Initialize user-secrets, then set your endpoint, key, and model. Get these from
-the Azure AI Foundry portal (**https://ai.azure.com**).
+the Azure AI Foundry portal (**[https://ai.azure.com](https://ai.azure.com/)**).
 
 ```bash
 dotnet user-secrets init
@@ -128,7 +128,7 @@ caching, and telemetry.
 dotnet run
 ```
 
-```
+```text
 Chat app ready. Type a message (or 'exit' to quit).
 
 You: Give me one tip for learning .NET

--- a/Part 2 - Project Creation/GenAiLab/README.md
+++ b/Part 2 - Project Creation/GenAiLab/README.md
@@ -16,6 +16,10 @@ This incompatibility can be addressed by upgrading to Docker Desktop 4.41.1. See
 # Configure the AI Model Provider
 
 ## Using GitHub Models
+
+> [!WARNING]
+> **GitHub Models is [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Use it only as a temporary legacy fallback — prefer **Azure OpenAI** (see the Azure OpenAI section below).
+
 To use models hosted by GitHub Models, you will need to create a GitHub personal access token. The token should not have any scopes or permissions. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 From the command line, configure your token for this project using .NET User Secrets by running the following commands:

--- a/Part 3 - Add RAG/README.md
+++ b/Part 3 - Add RAG/README.md
@@ -13,7 +13,7 @@ piece because you wrote it yourself.
 
 ## What you will build
 
-```
+```text
 question ─▶ embed ─▶ cosine search over stored chunks ─▶ top-k context
                                                               │
 document ─▶ chunk ─▶ embed ─▶ store (in-memory list) ─────────┘
@@ -115,7 +115,7 @@ Run it and ask something only the document knows:
 dotnet run
 ```
 
-```
+```text
 You: How do I dry the boots?
 Assistant: Air-dry them away from direct heat. Never place them on a radiator,
 as that damages the waterproof membrane.

--- a/Part 3 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
+++ b/Part 3 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
@@ -24,7 +24,7 @@ direct heat; never place the boots on a radiator, as this damages the membrane.
 
 The TrailBlazer 3000 includes a 2-year limited warranty covering manufacturing
 defects. The warranty does not cover normal wear of the sole or damage from
-improper drying. To make a claim, contact support@contoso.example with your order
+improper drying. To make a claim, contact <support@contoso.example> with your order
 number.
 
 ## Return policy

--- a/Part 4 - Azure OpenAI/README.md
+++ b/Part 4 - Azure OpenAI/README.md
@@ -9,6 +9,8 @@ In this workshop, you will learn how to migrate your application from using GitH
 > [!IMPORTANT]
 > **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). It appears here only as a legacy starting point — **Azure AI Foundry (Azure OpenAI)** is the recommended provider.
 
+<!-- -->
+
 > [!TIP]
 > **Alternative AI Providers**: While this workshop focuses on migrating from GitHub Models to Azure OpenAI, the same principles apply to other providers:
 >

--- a/Part 4 - Azure OpenAI/README.md
+++ b/Part 4 - Azure OpenAI/README.md
@@ -6,12 +6,15 @@
 
 In this workshop, you will learn how to migrate your application from using GitHub Models during development to Azure OpenAI for production. You'll understand how the common interfaces in Microsoft Extensions for AI make this migration seamless, create an Azure OpenAI resource, deploy models, and update your application's configuration.
 
+> [!IMPORTANT]
+> **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). It appears here only as a legacy starting point — **Azure AI Foundry (Azure OpenAI)** is the recommended provider.
+
 > [!TIP]
 > **Alternative AI Providers**: While this workshop focuses on migrating from GitHub Models to Azure OpenAI, the same principles apply to other providers:
 >
 > - **Azure OpenAI** (covered here): Simpler setup, better error handling, higher token limits - recommended if you have Azure access
 > - **OpenAI** (direct): Similar to Azure OpenAI but with different pricing and terms - see [OpenAI documentation](https://platform.openai.com/docs/quickstart) for setup
-> - **GitHub Models**: Great for getting started and learning, with free tier access for all GitHub users
+> - **GitHub Models** (legacy — retiring July 30, 2026): Was great for getting started with free access for all GitHub users; prefer Azure AI Foundry now
 >
 > Choose the provider that best fits your access and requirements. The beauty of Microsoft Extensions for AI is that switching between providers requires minimal code changes.
 

--- a/Part 4 - Template reveal/README.md
+++ b/Part 4 - Template reveal/README.md
@@ -14,6 +14,8 @@ faith.
 > memory and vanished on exit. A production app needs a persistent, orchestrated
 > vector database.
 
+<!-- -->
+
 > RAG evaluation (the "RAG triad": groundedness, relevance, context quality) is a
 > great optional enrichment for this part — see
 > [Steve Sanderson's dotnet-ai-workshop, Ch 6](https://github.com/SteveSandersonMS/dotnet-ai-workshop). Reference and adapt with attribution.

--- a/Part 5 - Products Page/GenAiLab/README.md
+++ b/Part 5 - Products Page/GenAiLab/README.md
@@ -16,6 +16,10 @@ This incompatibility can be addressed by upgrading to Docker Desktop 4.41.1. See
 # Configure the AI Model Provider
 
 ## Using GitHub Models
+
+> [!WARNING]
+> **GitHub Models is [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Use it only as a temporary legacy fallback — prefer **Azure OpenAI** (see the Azure OpenAI section below).
+
 To use models hosted by GitHub Models, you will need to create a GitHub personal access token. The token should not have any scopes or permissions. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 From the command line, configure your token for this project using .NET User Secrets by running the following commands:

--- a/Part 6 - Deployment/GenAiLab/README.md
+++ b/Part 6 - Deployment/GenAiLab/README.md
@@ -16,6 +16,10 @@ This incompatibility can be addressed by upgrading to Docker Desktop 4.41.1. See
 # Configure the AI Model Provider
 
 ## Using GitHub Models
+
+> [!WARNING]
+> **GitHub Models is [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Use it only as a temporary legacy fallback — prefer **Azure OpenAI** (see the Azure OpenAI section below).
+
 To use models hosted by GitHub Models, you will need to create a GitHub personal access token. The token should not have any scopes or permissions. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 From the command line, configure your token for this project using .NET User Secrets by running the following commands:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Get up to speed quickly with AI app building in .NET! Explore the new .NET AI project templates integrated with Microsoft Extensions for AI (MEAI), Azure AI Foundry, and vector data stores. Learn how to build with Azure AI Foundry (Azure OpenAI) models for both development and production, with GitHub Models and local models (Foundry Local / Ollama) available as fallbacks. Gain hands-on experience building cutting-edge intelligent solutions with state-of-the-art frameworks and best practices.
 
+> [!IMPORTANT]
+> **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (with brownouts on July 16 and 23). This workshop uses **Azure AI Foundry (Azure OpenAI)** as the primary provider; GitHub Models appears only as a legacy fallback. See [Part 5 - Providers and Fallbacks](Part%205%20-%20Providers%20and%20Fallbacks/README.md).
+
 ## Prerequisites
 
 ### AI Web Chat Application Requirements (Parts 1-6)
@@ -128,7 +131,7 @@ Throughout this lab, you'll implement each part of this architecture, from setti
 - 🧠 **Microsoft Extensions for AI (MEAI)**: Libraries for integrating AI capabilities into .NET applications
 - 🔥 **Blazor**: For building interactive web UIs
 - 🌐 **.NET Aspire**: For orchestrating cloud-native distributed applications
-- 🐱 **GitHub Models**: Free AI models for development
+- 🐱 **GitHub Models** (legacy — [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)): Free during development; use Azure AI Foundry instead
 - ☁️ **Azure OpenAI**: Enterprise-grade AI models for production
 - 🔮 **Qdrant Vector Database**: For storing and searching vector embeddings
 


### PR DESCRIPTION
## Summary

Adds consistent **GitHub Models retirement** messaging so no learner-facing page presents it as the default/recommended provider without a warning. Resolves #494.

Reference: https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/

## Changes

Retirement banners / legacy labeling (retires **2026-07-30**, brownouts **July 16 & 23**, pointing to Azure AI Foundry) added to:

- **Root `README.md`** — top `[!IMPORTANT]` banner + legacy label on the GitHub Models tech bullet
- **Part 1 - Setup** — top retirement banner
- **Part 4 - Azure OpenAI** — retirement banner + legacy label on the provider bullet
- **Part 2 / Part 5 / Part 6 GenAiLab READMEs** — `[!WARNING]` under the "Using GitHub Models" section (was presented first, without warning)
- **`.github/copilot-instructions.md`** — GitHub Models marked legacy dev-only, retiring
- **`.github/.devcontainer/README.md`** — legacy note on the GitHub-account container criterion

## Acceptance

- ✅ No page presents GitHub Models as the recommended/default provider without a retirement warning
- ✅ Brownout (July 16 & 23) and full-retirement (July 30) dates surfaced where relevant
- ✅ Prereq lists already mark the GitHub account as optional/legacy (root + Part 1)

## Notes

- Several edited pages live in the old-structure parts (Part 2/4/5/6 folders); banners are added now because the retirement is time-sensitive (pre-July brownouts). The folder renumber/dedupe happens later in the restructure pass (#503).
- The new hands-on parts (2–5) and Part 5 providers doc already carried this messaging.
