### PR TITLE
chore(deps): consolidate Dependabot NuGet bumps (#514-#522)

### DIFF
--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 

--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageReference Include="PdfPig" Version="0.1.13" />
+    <PackageReference Include="PdfPig" Version="0.1.15" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="13.4.6" />

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -11,9 +11,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -10,14 +10,14 @@
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.72.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
     <PackageReference Include="PdfPig" Version="0.1.14" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="13.1.2" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.61.0-preview" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot NuGet update PRs (#514–#522) into a single change so they can be reviewed, built, and merged together.

Closes #514, #515, #516, #517, #518, #519, #520, #521, #522.

## Package updates

### Part 2 - Project Creation / GenAiLab.ServiceDefaults
- `OpenTelemetry.Instrumentation.AspNetCore` 1.15.2 → **1.16.0** (#514)
- `OpenTelemetry.Instrumentation.Http` 1.15.1 → **1.16.0** (#515)

### Part 2 - Project Creation / GenAiLab.Web
- `PdfPig` 0.1.13 → **0.1.15** (#516)

### Part 6 - Deployment / GenAiLab.ServiceDefaults
- `Microsoft.Extensions.ServiceDiscovery` 10.3.0 → **10.7.0** (#518)
- `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.3 → **1.16.0** (#521)
- `OpenTelemetry.Extensions.Hosting` 1.15.0 → **1.16.0** (#522)

### Part 6 - Deployment / GenAiLab.Web
- `Microsoft.AspNetCore.Components.QuickGrid` 9.0.16 → **9.0.17** (#517)
- `Microsoft.Extensions.VectorData.Abstractions` 10.6.0 → **10.7.0** (#519)
- `Microsoft.SemanticKernel.Core` 1.72.0 → **1.77.0** (#520)

## Additional change required for the build

`Microsoft.SemanticKernel.Core` 1.77.0 requires `Microsoft.Extensions.AI >= 10.5.0`. Part 6's Web project pinned it at 10.3.0, which caused an `NU1605` downgrade error. To resolve it, `Microsoft.Extensions.AI` and `Microsoft.Extensions.AI.OpenAI` in **Part 6 - Deployment / GenAiLab.Web** were bumped 10.3.0 → **10.7.0** (matching Part 2).

## Validation

- `dotnet build "Part 2 - Project Creation/GenAiLab/GenAiLab.sln" -c Release` — succeeded, 0 warnings, 0 errors.
- `dotnet build "Part 6 - Deployment/GenAiLab/GenAiLab.sln" -c Release` — succeeded, 0 warnings, 0 errors.
