### PR TITLE
chore(deps): consolidate PRs #525-#528 and enable optimistic Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      nuget-all:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10

--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
   </ItemGroup>
 
 </Project>

--- a/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
     <PackageReference Include="PdfPig" Version="0.1.15" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.78.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="13.4.6" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.61.0-preview" />

--- a/Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj
+++ b/Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.6.25358.103" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
 
 </Project>

--- a/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
+++ b/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
 
 </Project>

--- a/Part 9 - MCP Publishing/README.md
+++ b/Part 9 - MCP Publishing/README.md
@@ -88,8 +88,8 @@ For this example, we'll publish the **MyMcpServer** from Part 7. First, update t
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary

Consolidates current open Dependabot NuGet updates into one PR and configures Dependabot to aggressively minimize future NuGet PR count by grouping all NuGet dependencies together.

Supersedes: #525, #526, #527, #528.

## Consolidated dependency updates

- `Part 2 - Project Creation/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj`
  - `Microsoft.SemanticKernel.Core` `1.77.0` -> `1.78.0` (#525)

- `Part 2 - Project Creation/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj`
  - `OpenTelemetry.Instrumentation.Runtime` `1.15.1` -> `1.16.0` (#526)

- `Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj`
  - `Microsoft.Extensions.Hosting` `10.0.0-preview.6.25358.103` -> `10.0.9` (#527)
  - `ModelContextProtocol` `0.4.0-preview.1` -> `1.4.1` (#528)

## Dependabot grouping update (optimistic grouping)

Updated `.github/dependabot.yml` to group all NuGet dependencies into a single group:

```yaml
groups:
  nuget-all:
    patterns:
      - "*"
```

This is intentionally broad to minimize the number of Dependabot PRs by grouping as much as possible.

## Validation

- `dotnet build "Part 2 - Project Creation/GenAiLab/GenAiLab.sln" -c Release` (pass)
- `dotnet build "Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj" -c Release` (pass)
