### PR TITLE
docs: start #503 workshop flow alignment

### DIFF
--- a/Part 1 - Setup/README.md
+++ b/Part 1 - Setup/README.md
@@ -115,7 +115,7 @@ If you don't already have a GitHub account, follow these steps to create one:
 
 Ready to build your first AI application? Let's get started!
 
-**Continue to** → [Part 2: Create a Project with AI Web Chat Template](../Part%202%20-%20Project%20Creation/README.md)
+**Continue to** → [Part 2: Build Chat App](../Part%202%20-%20Build%20Chat%20App/README.md)
 
 In Part 2, you'll learn how to:
 

--- a/Part 4 - Template reveal/README.md
+++ b/Part 4 - Template reveal/README.md
@@ -1,4 +1,4 @@
-# Part 4: Template reveal — scaffold `aichatweb` and understand the code
+# Part 4: AI Web Chat Template — scaffold `aichatweb` and understand the code
 
 You've now built a chat app (Part 2) and a RAG loop (Part 3) **by hand**. You know
 what an `IChatClient` is, what an embedding is, what a vector search does, and why

--- a/README.md
+++ b/README.md
@@ -141,19 +141,21 @@ Follow the [setup instructions](Part%201%20-%20Setup/README.md) to get started w
 
 ## Lab Modules 📚
 
-The lab is divided into nine modules:
+The lab is divided into nine modules.
+
+The primary sequence below reflects the current converged workshop flow and keeps advanced modules explicitly optional for pacing.
 
 ### AI Web Chat Application (Parts 1-6)
 
 1. 🏗️ [**Setup**](Part%201%20-%20Setup/README.md): Configure prerequisites and development environment for the AI workshop.
 
-2. 🏗️ [**Project Creation**](Part%202%20-%20Project%20Creation/README.md): Build a web application using the .NET AI Web Chat template.
+2. 💬 [**Build Chat App**](Part%202%20-%20Build%20Chat%20App/README.md): Build and run a minimal console-based AI chat app.
 
-3. 🔍 [**Template Exploration**](Part%203%20-%20Template%20Exploration/README.md): Understand the implementation of vector embeddings, semantic search, and chat interfaces in AI Web Chat projects.
+3. 🧩 [**Add RAG**](Part%203%20-%20Add%20RAG/README.md): Add retrieval-augmented generation with embeddings and semantic search.
 
-4. ☁️ [**Azure OpenAI**](Part%204%20-%20Azure%20OpenAI/README.md): Transition from GitHub Models to the Azure OpenAI service for production-ready capabilities.
+4. 🔍 [**Template Reveal**](Part%204%20-%20Template%20reveal/README.md): Compare your manual implementation with the generated template architecture.
 
-5. 🛍️ [**Products Page**](Part%205%20-%20Products%20Page/README.md): Implement a product catalog that leverages AI for enhanced product information.
+5. 🔁 [**Providers and Fallbacks**](Part%205%20-%20Providers%20and%20Fallbacks/README.md): Configure provider options and fallback paths (Azure AI Foundry primary).
 
 6. 🚀 [**Deployment**](Part%206%20-%20Deployment/README.md): Deploy your application to Azure using the Azure Developer CLI.
 
@@ -161,9 +163,9 @@ The lab is divided into nine modules:
 
 1. 🔧 [**MCP Server Basics**](Part%207%20-%20MCP%20Server%20Basics/README.md): Create your first MCP server with weather tools that extend AI agents like GitHub Copilot.
 
-2. 🏢 [**Enhanced MCP Server**](Part%208%20-%20Enhanced%20MCP%20Server/README.md): Build sophisticated business tools for order management, inventory, and customer service scenarios.
+2. 🏢 [**Enhanced MCP Server**](Part%208%20-%20Enhanced%20MCP%20Server/README.md) *(Optional / bonus)*: Build sophisticated business tools for order management, inventory, and customer service scenarios.
 
-3. 📦 [**MCP Publishing**](Part%209%20-%20MCP%20Publishing/README.md): Package, publish, and distribute your MCP servers through NuGet for professional deployment.
+3. 📦 [**MCP Publishing**](Part%209%20-%20MCP%20Publishing/README.md) *(Optional / bonus)*: Package, publish, and distribute your MCP servers through NuGet for professional deployment.
 
 ## Lab Structure 📁
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The primary sequence below reflects the current converged workshop flow and keep
 
 3. 🧩 [**Add RAG**](Part%203%20-%20Add%20RAG/README.md): Add retrieval-augmented generation with embeddings and semantic search.
 
-4. 🔍 [**Template Reveal**](Part%204%20-%20Template%20reveal/README.md): Compare your manual implementation with the generated template architecture.
+4. 🔍 [**AI Web Chat Template**](Part%204%20-%20Template%20reveal/README.md): Compare your manual implementation with the generated template architecture.
 
 5. 🔁 [**Providers and Fallbacks**](Part%205%20-%20Providers%20and%20Fallbacks/README.md): Configure provider options and fallback paths (Azure AI Foundry primary).
 


### PR DESCRIPTION
## Summary

Starts issue #503 with a low-risk documentation slice that aligns the primary workshop path with the newer converged flow.

## Changes in this PR

- Updated root `README.md` lab module sequence to:
  - Part 2 **Build Chat App**
  - Part 3 **Add RAG**
  - Part 4 **Template reveal**
  - Part 5 **Providers and Fallbacks**
  - Kept deployment as Part 6
- Marked **Part 8 (Enhanced MCP)** and **Part 9 (MCP Publishing)** as **Optional / bonus** in the root guide.
- Updated `Part 1 - Setup/README.md` Next Steps link to point to **Part 2 - Build Chat App** instead of the legacy Project Creation path.

## Why this first

Issue #503 is broad (renumbering, removing Products Page from flow, cross-link cleanup, optional/bonus pacing cues). This PR lands immediate navigation clarity with minimal churn and no code changes.

## Validation

- `markdownlint README.md "Part 1 - Setup/README.md"` (pass)

Related to #503.
