### PR TITLE
Upgrade project and build references from .NET 9 to .NET 10

### DIFF
--- a/.github/.devcontainer/Ollama/devcontainer.json
+++ b/.github/.devcontainer/Ollama/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
     "name": "C# (.NET) - Ollama",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/common-utils:2": {},

--- a/.github/.devcontainer/README.md
+++ b/.github/.devcontainer/README.md
@@ -10,7 +10,7 @@ This workshop provides two development container configurations to suit differen
 
 **Includes:**
 
-- .NET 9.0 with Aspire workload
+- .NET 10.0 with Aspire workload
 - Docker-in-Docker (for Qdrant vector database)
 - Azure CLI and Azure Developer CLI
 - GitHub CLI

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
     "name": "C# (.NET)",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/common-utils:2": {},

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,17 +2,17 @@
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
-This repository contains a comprehensive .NET AI workshop with 9 parts covering AI web chat applications and Model Context Protocol (MCP) servers. The workshop teaches building AI-powered applications using .NET 9, Blazor, Microsoft Extensions for AI, GitHub Models, Azure OpenAI, and vector databases.
+This repository contains a comprehensive .NET AI workshop with 9 parts covering AI web chat applications and Model Context Protocol (MCP) servers. The workshop teaches building AI-powered applications using .NET 10, Blazor, Microsoft Extensions for AI, GitHub Models, Azure OpenAI, and vector databases.
 
 ## Working Effectively
 
 ### Prerequisites and Environment Setup
-- Install .NET 9.0 SDK for AI Web Chat applications (Parts 1-6):
+- Install .NET 10.0 SDK for AI Web Chat applications (Parts 1-6):
   ```bash
-  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 10.0
   export PATH="$HOME/.dotnet:$PATH"
   ```
-- Install .NET 8.0 SDK for MCP servers (Parts 7-8) - typically already available
+- Install .NET 10.0 SDK for MCP servers (Parts 7-9)
 - Install Docker Desktop or Podman (required for .NET Aspire orchestration and Qdrant vector database)
 - Install Microsoft Extensions AI templates:
   ```bash
@@ -30,7 +30,7 @@ This repository contains a comprehensive .NET AI workshop with 9 parts covering 
 
 ### Major Project Solutions
 1. **Part 4 AI Web Chat Template (Basic)**: `Part 4 - AI Web Chat Template/GenAiLab/GenAiLab.sln`
-   - .NET 9.0 solution with Blazor web app, service defaults, and AppHost
+  - .NET 10.0 solution with Blazor web app, service defaults, and AppHost
    - Build time: ~11 seconds, Restore time: ~18 seconds
    
 2. **Part 6 AI Web Chat (Full)**: `Part 6 - Deployment/GenAiLab/GenAiLab.sln`
@@ -38,11 +38,11 @@ This repository contains a comprehensive .NET AI workshop with 9 parts covering 
    - Same build timing as Part 2
    
 3. **Part 7 MCP Server (Basic)**: `Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj`
-   - .NET 8.0 MCP server with weather tools
+  - .NET 10.0 MCP server with weather tools
    - Build time: ~2 seconds, Restore time: ~5 seconds
    
 4. **Part 8 MCP Server (Enhanced)**: `Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj`
-   - .NET 8.0 business MCP server with order management tools
+  - .NET 10.0 business MCP server with order management tools
    - Build time: ~4 seconds with 3 warnings (expected)
 
 ### Running Applications
@@ -154,8 +154,8 @@ dotnet new mcpserver --help
 
 ## Key Technologies Used
 
-- **.NET 9**: AI Web Chat applications with Blazor and .NET Aspire
-- **.NET 8**: MCP server applications  
+- **.NET 10**: AI Web Chat applications with Blazor and .NET Aspire
+- **.NET 10**: MCP server applications  
 - **Microsoft Extensions for AI**: Core AI integration libraries
 - **GitHub Models**: Legacy dev-only provider, retiring July 30, 2026 — use [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI) instead
 - **Azure OpenAI**: Enterprise-grade AI models for production
@@ -167,7 +167,7 @@ dotnet new mcpserver --help
 
 ### Build Issues
 - Ensure correct .NET SDK version is installed and in PATH
-- For .NET 9 issues, verify SDK installation: `dotnet --list-sdks | grep 9.0`
+- For .NET 10 issues, verify SDK installation: `dotnet --list-sdks | grep 10.0`
 - For Docker issues with AI Web Chat, ensure Docker Desktop is running
 
 ### Template Issues  

--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -122,7 +122,7 @@ The script will check for the required environment variables and prompt for any 
 
 5. **Complete Implementation Requirements**: Parts 5-6 require full code implementation, not just documentation. Part 5 must include complete Products page functionality, and Part 6 must contain the complete application from Part 5 plus deployment configuration.
 
-6. **MCP Prerequisites**: Parts 7-9 require .NET 10 SDK preview and Visual Studio Code with GitHub Copilot extension. Part 7 uses `MyMcpServer` project that includes both template-generated RandomNumberTools and custom WeatherTools. **Note**: A partial test run covering only Parts 1-6 can be performed with .NET 9 SDK alone.
+6. **MCP Prerequisites**: Parts 7-9 require .NET 10 SDK and Visual Studio Code with GitHub Copilot extension. Part 7 uses `MyMcpServer` project that includes both template-generated RandomNumberTools and custom WeatherTools.
 
 7. **MCP VS Code Integration Testing**: For Parts 7-8, VS Code integration testing involves:
    - Verifying the MCP server starts correctly when run via `dotnet run`
@@ -269,7 +269,7 @@ Compare with reference code snapshot in `Part 7 - MCP Server Basics/MyMcpServer/
 
 **Important Considerations**:
 - **Approach**: Build and run existing snapshot rather than creating new project
-- **Target Framework**: .NET 8.0 (different from Part 7's .NET 9/10)
+- **Target Framework**: .NET 10.0 (aligned with Part 7)
 - **Expected Warnings**: 3 CS1998 warnings about async methods without await - these are acceptable
   - ContosoOrdersTools.cs lines 13, 61, 93
   - Methods return synchronous data but use async signature for API consistency
@@ -346,8 +346,8 @@ This workshop specifically tests the template generation workflow. Manual projec
 - **Recommendation**: Update generated code to match reference snapshot pattern for consistency, or update snapshots to match current template output
 
 **Issue**: MCP servers target different .NET framework versions
-- **Part 7 MyMcpServer**: Template generates for .NET 9.0 (using .NET 10 SDK)
-- **Part 8 ContosoOrdersMcpServer**: Targets .NET 8.0
+- **Part 7 MyMcpServer**: Targets .NET 10.0
+- **Part 8 ContosoOrdersMcpServer**: Targets .NET 10.0
 - **Impact**: Build requires appropriate SDK version available
 - **Resolution**: Verify SDK version with `dotnet --list-sdks` before building
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -29,13 +29,13 @@ jobs:
           - solution: "Part 2 - Build Chat App/ChatApp/ChatApp.csproj"
             dotnet-version: '10.0.x'
           - solution: "Part 6 - Deployment/GenAiLab/GenAiLab.sln"
-            dotnet-version: '9.0.x'
+            dotnet-version: '10.0.x'
           # No solution file exists for MyMcpServer; using project file directly
           - solution: "Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj"
-            dotnet-version: '9.0.x'
+            dotnet-version: '10.0.x'
           # No solution file exists for ContosoOrdersMcpServer; using project file directly
           - solution: "Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj"
-            dotnet-version: '9.0.x'
+            dotnet-version: '10.0.x'
 
     steps:
     - name: Checkout code

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/GenAiLab.AppHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>7cb971c7-91be-4e8c-a48d-0d33a430b84f</UserSecretsId>

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.ServiceDefaults/GenAiLab.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>233010f4-eff2-4b12-922a-edeabb53bbdc</UserSecretsId>
@@ -16,7 +16,7 @@
     <PackageReference Include="PdfPig" Version="0.1.15" />
     <PackageReference Include="Aspire.Qdrant.Client" Version="13.4.6" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.61.0-preview" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.8.0" />
   </ItemGroup>
 

--- a/Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj
+++ b/Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-arm64;linux-x64;linux-arm64;linux-musl-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
+++ b/Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/Part 9 - MCP Publishing/README.md
+++ b/Part 9 - MCP Publishing/README.md
@@ -66,7 +66,7 @@ For this example, we'll publish the **MyMcpServer** from Part 7. First, update t
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     
     <!-- NuGet Package Information -->
@@ -267,7 +267,7 @@ Can you give me a 5-day forecast for London?
 
 ## Requirements
 
-- .NET 8.0 or higher
+- .NET 10.0 or higher
 - MCP-compatible client (VS Code with Copilot, Visual Studio, etc.)
 
 ## License


### PR DESCRIPTION
This pull request updates the entire workshop to use .NET 10.0 as the standard SDK and target framework, replacing previous references to .NET 9.0 and .NET 8.0. This change ensures consistency across all project files, documentation, development containers, and CI workflows. Additionally, a package reference is updated to match the new .NET version.

Key updates include:

**Project and Solution Target Frameworks**
* All main project files now target `net10.0`, including `GenAiLab.AppHost`, `GenAiLab.ServiceDefaults`, `GenAiLab.Web`, `MyMcpServer`, and `ContosoOrdersMcpServer`. [[1]](diffhunk://#diff-d3d4480f73740b45a00267c803d34c6779232217e7140f7027f3802dbb0c0b70L7-R7) [[2]](diffhunk://#diff-b1a3504b1944c41466d9a86847d513d3e3b8dfec03ea5bc1c9eabc6a0af3a58bL4-R4) [[3]](diffhunk://#diff-a8841c7094787ef09080bd130819147cea131b1136ce8a58098efe22d2e44342L4-R4) [[4]](diffhunk://#diff-2d1cd6ef87cec729ecb59b6f09b0b0397c1b576722c74d9a2aa326ebc43b84f8L4-R4) [[5]](diffhunk://#diff-e107a80edd592176c47377611c307432b3471ac8549be168384876ddae9c4edeL4-R4)

**Development Environment and CI/CD**
* Development container definitions (`devcontainer.json` and `Ollama/devcontainer.json`) now use the `mcr.microsoft.com/devcontainers/dotnet:10.0` image. [[1]](diffhunk://#diff-eb9bb21ed32d898edee8eeadd622f248588149a246d7d555cdc03095515bf052L5-R5) [[2]](diffhunk://#diff-b4837f6a25622d6b4c6e04bf9c7c9291d8e1a011a2e5f44855f872af06c0d968L5-R5)
* The GitHub Actions workflow (`dotnet-build.yml`) is updated to use `dotnet-version: '10.0.x'` for all build steps.

**Documentation and Instructions**
* All documentation, including `README.md` and `copilot-instructions.md`, is updated to reference .NET 10.0 for both AI Web Chat and MCP server projects, and to update installation instructions and technology descriptions accordingly. [[1]](diffhunk://#diff-eaa43fa9635876856ab6b5eb805dab32ee74b5fecc7eb388c412b4d2d472c7d3L13-R13) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L5-R15) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L33-R45) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L157-R158) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L170-R170)
* Prompt and test instructions are revised to align with .NET 10.0 as the required SDK for all parts, removing references to .NET 8.0 and preview requirements. [[1]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L125-R125) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L272-R272) [[3]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L349-R350)

**Dependency Updates**
* The `Microsoft.AspNetCore.Components.QuickGrid` package is updated to version `10.0.0` in `GenAiLab.Web.csproj` to match the new target framework.