### PR TITLE
Remove GitHub Models references and simplify workshop homepage

### DIFF
--- a/.github/.devcontainer/README.md
+++ b/.github/.devcontainer/README.md
@@ -18,7 +18,6 @@ This workshop provides two development container configurations to suit differen
 
 **Use this if you:**
 
-- Have a GitHub account for GitHub Models (legacy fallback, [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/) — prefer [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry))
 - Plan to use Azure OpenAI
 - Want to follow the workshop as designed
 
@@ -33,8 +32,6 @@ This workshop provides two development container configurations to suit differen
 
 **Use this if you:**
 
-- Don't have a GitHub account
-- Hit GitHub Models token limits
 - Want to work completely offline
 - Prefer using local models for privacy/security
 - Want to experiment with different models

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
-This repository contains a comprehensive .NET AI workshop with 9 parts covering AI web chat applications and Model Context Protocol (MCP) servers. The workshop teaches building AI-powered applications using .NET 10, Blazor, Microsoft Extensions for AI, GitHub Models, Azure OpenAI, and vector databases.
+This repository contains a comprehensive .NET AI workshop with 9 parts covering AI web chat applications and Model Context Protocol (MCP) servers. The workshop teaches building AI-powered applications using .NET 10, Blazor, Microsoft Extensions for AI, Microsoft Foundry (Azure OpenAI), and vector databases.
 
 ## Working Effectively
 
@@ -81,7 +81,7 @@ This repository contains a comprehensive .NET AI workshop with 9 parts covering 
 ### Manual Validation Scenarios
 - **ALWAYS run through complete scenarios** after making changes:
   1. **MCP Server Validation**: Run MCP server and verify it starts with proper logging output and responds to Ctrl+C shutdown
-  2. **AI Web Chat Validation**: Requires GitHub token or Azure OpenAI credentials for full testing
+  2. **AI Web Chat Validation**: Requires Azure OpenAI credentials for full testing
   3. **Template Validation**: Test creating new projects with templates:
      ```bash
      dotnet new aichatweb --name TestApp --output /tmp/test-app
@@ -97,7 +97,7 @@ This repository contains a comprehensive .NET AI workshop with 9 parts covering 
 ```bash
 dotnet new aichatweb --help  # See all options
 # Key options:
-# --provider: githubmodels (default), azureopenai, ollama, openai
+# --provider: azureopenai, ollama, openai
 # --vector-store: local (default), azureaisearch, qdrant
 # --aspire: false (default), true for distributed applications
 ```
@@ -143,8 +143,8 @@ dotnet new mcpserver --help
 ```
 
 ### Credential Management
-- Use `.github/scripts/setup-workshop-credentials.ps1` for setting up GitHub and Azure credentials
-- Environment variables: `WORKSHOP_GITHUB_TOKEN`, `WORKSHOP_AZURE_OPENAI_ENDPOINT`, `WORKSHOP_AZURE_OPENAI_KEY`
+- Use `.github/scripts/setup-workshop-credentials.ps1` for setting up Azure credentials
+- Environment variables: `WORKSHOP_AZURE_OPENAI_ENDPOINT`, `WORKSHOP_AZURE_OPENAI_KEY`
 
 ### Timing Expectations
 - **NEVER CANCEL**: All builds complete in under 30 seconds. Set timeout to 300+ seconds minimum.
@@ -157,7 +157,7 @@ dotnet new mcpserver --help
 - **.NET 10**: AI Web Chat applications with Blazor and .NET Aspire
 - **.NET 10**: MCP server applications  
 - **Microsoft Extensions for AI**: Core AI integration libraries
-- **GitHub Models**: Legacy dev-only provider, retiring July 30, 2026 — use [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI) instead
+- **Microsoft Foundry (Azure OpenAI)**: Cloud AI provider used for workshop exercises
 - **Azure OpenAI**: Enterprise-grade AI models for production
 - **Qdrant**: Vector database for embeddings and semantic search
 - **Docker**: Container orchestration for vector databases

--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -93,7 +93,6 @@ Parts 1, 3, and 9 contain only README files as they focus on setup, exploration,
 
 Before starting the workshop, the following environment variables should be checked and configured if needed:
 
-- `WORKSHOP_GITHUB_TOKEN` - GitHub personal access token for GitHub Models access
 - `WORKSHOP_AZURE_OPENAI_ENDPOINT` - Azure OpenAI service endpoint URL
 - `WORKSHOP_AZURE_OPENAI_KEY` - Azure OpenAI service API key
 - `WORKSHOP_AZURE_SUBSCRIPTION_ID` - Azure subscription ID for deployment
@@ -112,19 +111,17 @@ The script will check for the required environment variables and prompt for any 
 
 ## Important Notes for Testing
 
-1. **GitHub Token**: Use the `WORKSHOP_GITHUB_TOKEN` environment variable. Classic token (no specific scopes needed) or fine-grained token with `models:read` scope.
+1. **Azure OpenAI Credentials**: Use the `WORKSHOP_AZURE_OPENAI_ENDPOINT` and `WORKSHOP_AZURE_OPENAI_KEY` environment variables.
 
-2. **Azure OpenAI Credentials**: Use the `WORKSHOP_AZURE_OPENAI_ENDPOINT` and `WORKSHOP_AZURE_OPENAI_KEY` environment variables.
+2. **Template Parameter Critical Requirement**: Always use `--vector-store qdrant` when generating AI Web Chat templates. Missing this parameter causes templates to use SQLite instead of Qdrant, leading to documentation misalignment.
 
-3. **Template Parameter Critical Requirement**: Always use `--vector-store qdrant` when generating AI Web Chat templates. Missing this parameter causes templates to use SQLite instead of Qdrant, leading to documentation misalignment.
+3. **JavaScript File Dependencies**: The AI Web Chat template includes essential JavaScript files (ChatInput.razor.js, ChatMessageList.razor.js) that provide auto-resize textarea and auto-scroll functionality. These files must be preserved in all code snapshots.
 
-4. **JavaScript File Dependencies**: The AI Web Chat template includes essential JavaScript files (ChatInput.razor.js, ChatMessageList.razor.js) that provide auto-resize textarea and auto-scroll functionality. These files must be preserved in all code snapshots.
+4. **Complete Implementation Requirements**: Parts 5-6 require full code implementation, not just documentation. Part 5 must include complete Products page functionality, and Part 6 must contain the complete application from Part 5 plus deployment configuration.
 
-5. **Complete Implementation Requirements**: Parts 5-6 require full code implementation, not just documentation. Part 5 must include complete Products page functionality, and Part 6 must contain the complete application from Part 5 plus deployment configuration.
+5. **MCP Prerequisites**: Parts 7-9 require .NET 10 SDK and Visual Studio Code with GitHub Copilot extension. Part 7 uses `MyMcpServer` project that includes both template-generated RandomNumberTools and custom WeatherTools.
 
-6. **MCP Prerequisites**: Parts 7-9 require .NET 10 SDK and Visual Studio Code with GitHub Copilot extension. Part 7 uses `MyMcpServer` project that includes both template-generated RandomNumberTools and custom WeatherTools.
-
-7. **MCP VS Code Integration Testing**: For Parts 7-8, VS Code integration testing involves:
+6. **MCP VS Code Integration Testing**: For Parts 7-8, VS Code integration testing involves:
    - Verifying the MCP server starts correctly when run via `dotnet run`
    - Checking that the server responds to stdio communication protocol
    - Confirming proper shutdown with Ctrl+C
@@ -151,7 +148,7 @@ The workshop uses a per-unit directory structure where each part is self-contain
 
 - **Part 1** contains no code changes and does not require a working directory.
 
-- **For Part 2**, follow the README instructions to create a new project using `dotnet new aichatweb -n GenAiLab --provider githubmodels --aspire --vector-store qdrant` in a test working directory (e.g., `test-workspace/GenAiLab/`). **CRITICAL**: You must use the `dotnet new` command to create the project - never copy snapshots or create `.csproj` files manually.
+- **For Part 2**, follow the README instructions to create a new project using `dotnet new aichatweb -n GenAiLab --provider azureopenai --aspire --vector-store qdrant` in a test working directory (e.g., `test-workspace/GenAiLab/`). **CRITICAL**: You must use the `dotnet new` command to create the project - never copy snapshots or create `.csproj` files manually.
   - **At the end of Part 2**, compare your working directory with the code snapshot in `Part 4 - AI Web Chat Template/GenAiLab/`
   - **After reconciling differences**, replace the contents of `Part 4 - AI Web Chat Template/GenAiLab/` with your working directory code as the updated snapshot
 
@@ -196,7 +193,7 @@ The workshop uses a per-unit directory structure where each part is self-contain
 1. **Part 1 - Setup**: Follow the README.md in `Part 1 - Setup/` for prerequisites and environment setup.
 
 2. **Part 2 - Build Chat App**: 
-   - Follow the README.md instructions to create a new project using `dotnet new aichatweb -n GenAiLab --provider githubmodels --aspire --vector-store qdrant` in `test-workspace/GenAiLab/`
+  - Follow the README.md instructions to create a new project using `dotnet new aichatweb -n GenAiLab --provider azureopenai --aspire --vector-store qdrant` in `test-workspace/GenAiLab/`
    - **Immediately**: Copy the generated project to `src/start/` as the initial snapshot
    - Verify it builds and runs with basic chat functionality
   - **End of Part 2**: Compare with `Part 4 - AI Web Chat Template/GenAiLab/`, document differences, then replace that snapshot with your working code
@@ -228,7 +225,7 @@ The workshop uses a per-unit directory structure where each part is self-contain
 
 **Part 1**: Environment setup and prerequisites verification.
 
-**Part 2**: Create a new project using `dotnet new aichatweb -n GenAiLab --provider githubmodels --aspire --vector-store qdrant` as instructed in the README. Test that the generated project builds and runs with basic chat functionality. At end of part, compare with `Part 4 - AI Web Chat Template/GenAiLab/`, document differences, then replace that snapshot. **CRITICAL**: You must create the project using `dotnet new` - never copy existing snapshots or create `.csproj` files manually.
+**Part 2**: Create a new project using `dotnet new aichatweb -n GenAiLab --provider azureopenai --aspire --vector-store qdrant` as instructed in the README. Test that the generated project builds and runs with basic chat functionality. At end of part, compare with `Part 4 - AI Web Chat Template/GenAiLab/`, document differences, then replace that snapshot. **CRITICAL**: You must create the project using `dotnet new` - never copy existing snapshots or create `.csproj` files manually.
 
 **Part 3**: Verify Add RAG documentation clarity using the project you created in Part 2.
 
@@ -383,7 +380,6 @@ This workshop specifically tests the template generation workflow. Manual projec
 .\.github\scripts\setup-workshop-credentials.ps1
 
 # Verify environment variables
-Write-Host "GitHub Token: $($env:WORKSHOP_GITHUB_TOKEN -ne $null ? 'Set' : 'Not Set')"
 Write-Host "Azure Endpoint: $($env:WORKSHOP_AZURE_OPENAI_ENDPOINT -ne $null ? 'Set' : 'Not Set')"
 ```
 
@@ -416,7 +412,7 @@ dotnet build --configuration Release
 # Part 2: Create AI Web Chat project using dotnet new
 New-Item -ItemType Directory -Path "test-workspace" -Force
 cd test-workspace
-dotnet new aichatweb -n GenAiLab --provider githubmodels --aspire --vector-store qdrant
+dotnet new aichatweb -n GenAiLab --provider azureopenai --aspire --vector-store qdrant
 
 # At end of Part 2, compare and update snapshot
 code --diff "GenAiLab" "../Part 4 - AI Web Chat Template/GenAiLab"

--- a/.github/scripts/setup-workshop-credentials.ps1
+++ b/.github/scripts/setup-workshop-credentials.ps1
@@ -5,7 +5,6 @@
 
 .DESCRIPTION
     This script checks for and configures the required environment variables for the AI Workshop:
-    - WORKSHOP_GITHUB_TOKEN: GitHub personal access token for GitHub Models
     - WORKSHOP_AZURE_OPENAI_ENDPOINT: Azure OpenAI service endpoint URL
     - WORKSHOP_AZURE_OPENAI_KEY: Azure OpenAI service API key
     - WORKSHOP_AZURE_SUBSCRIPTION_ID: Azure subscription ID for deployment
@@ -25,27 +24,6 @@
 
 function Set-WorkshopCredentials {
     Write-Host "=== AI Workshop Credential Setup ===" -ForegroundColor Cyan
-    Write-Host ""
-    
-    # Check for GitHub Token
-    if (-not $env:WORKSHOP_GITHUB_TOKEN) {
-        Write-Host "GitHub token not found in environment variable WORKSHOP_GITHUB_TOKEN" -ForegroundColor Yellow
-        Write-Host "Create a classic token (no scopes needed) or fine-grained token with 'models:read' scope"
-        Write-Host "See: https://github.blog/changelog/2025-05-15-modelsread-now-required-for-github-models-access/"
-        Write-Host ""
-        
-        $githubToken = Read-Host -Prompt "Enter your GitHub personal access token" -AsSecureString
-        if ($githubToken.Length -gt 0) {
-            $env:WORKSHOP_GITHUB_TOKEN = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($githubToken))
-            [Environment]::SetEnvironmentVariable("WORKSHOP_GITHUB_TOKEN", $env:WORKSHOP_GITHUB_TOKEN, "User")
-            Write-Host "✓ GitHub token saved to environment variable WORKSHOP_GITHUB_TOKEN" -ForegroundColor Green
-        } else {
-            Write-Host "⚠ GitHub token was empty, skipping..." -ForegroundColor Yellow
-        }
-    } else {
-        Write-Host "✓ GitHub token found in environment variable WORKSHOP_GITHUB_TOKEN" -ForegroundColor Green
-    }
-    
     Write-Host ""
     
     # Check for Azure OpenAI Endpoint
@@ -185,7 +163,6 @@ function Set-WorkshopCredentials {
     # Show current status
     Write-Host ""
     Write-Host "Current credential status:" -ForegroundColor White
-    Write-Host "  GitHub Token: $($env:WORKSHOP_GITHUB_TOKEN -ne $null -and $env:WORKSHOP_GITHUB_TOKEN.Length -gt 0 ? 'Set' : 'Not Set')"
     Write-Host "  Azure Endpoint: $($env:WORKSHOP_AZURE_OPENAI_ENDPOINT -ne $null -and $env:WORKSHOP_AZURE_OPENAI_ENDPOINT.Length -gt 0 ? 'Set' : 'Not Set')"
     Write-Host "  Azure Key: $($env:WORKSHOP_AZURE_OPENAI_KEY -ne $null -and $env:WORKSHOP_AZURE_OPENAI_KEY.Length -gt 0 ? 'Set' : 'Not Set')"
     Write-Host "  Azure Subscription: $($env:WORKSHOP_AZURE_SUBSCRIPTION_ID -ne $null -and $env:WORKSHOP_AZURE_SUBSCRIPTION_ID.Length -gt 0 ? 'Set' : 'Not Set')"
@@ -193,7 +170,7 @@ function Set-WorkshopCredentials {
     Write-Host "  Azure AI Search Endpoint: $($env:WORKSHOP_AZURE_SEARCH_ENDPOINT -ne $null -and $env:WORKSHOP_AZURE_SEARCH_ENDPOINT.Length -gt 0 ? 'Set' : 'Not Set')" -ForegroundColor Gray
     Write-Host "  Azure AI Search Key: $($env:WORKSHOP_AZURE_SEARCH_KEY -ne $null -and $env:WORKSHOP_AZURE_SEARCH_KEY.Length -gt 0 ? 'Set' : 'Not Set')" -ForegroundColor Gray
     
-    if ($env:WORKSHOP_GITHUB_TOKEN -or $env:WORKSHOP_AZURE_OPENAI_ENDPOINT -or $env:WORKSHOP_AZURE_OPENAI_KEY) {
+    if ($env:WORKSHOP_AZURE_OPENAI_ENDPOINT -or $env:WORKSHOP_AZURE_OPENAI_KEY) {
         Write-Host ""
         Write-Host "Note: If you set new environment variables, restart your terminal/IDE to ensure they are loaded." -ForegroundColor Yellow
         Write-Host "You can now proceed with the AI Workshop!" -ForegroundColor Green

--- a/Part 1 - Setup/README.md
+++ b/Part 1 - Setup/README.md
@@ -6,9 +6,6 @@
 
 In this workshop, you will set up your development environment for building AI applications with .NET. You'll install the required tools and configure your environment to work with the workshop materials.
 
-> [!IMPORTANT]
-> **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Set up **[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI)** as your primary provider; the GitHub account below is only for the legacy fallback.
-
 ## Prerequisites
 
 Before starting, ensure you have:
@@ -18,7 +15,7 @@ Before starting, ensure you have:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop) or [Podman](https://podman.io/)
 - **An Azure subscription with access to [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI)** — the primary AI provider for this workshop
 - GitHub Copilot subscription (recommended; used later for the MCP and GitHub Copilot SDK units)
-- (Optional) A GitHub account — GitHub Models is available only as a legacy fallback that is [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)
+- (Optional) A GitHub account (recommended for contributor workflows such as cloning, branching, and pull requests)
 
 > [!TIP]
 > **No Azure access? Local fallback:** you can run local models with **Foundry Local** or **Ollama** for the chat exercises. See the [Development Container Options](./../.github/.devcontainer/README.md). Note that the full retrieval-augmented generation (RAG) exercise also needs an embedding model.
@@ -95,9 +92,9 @@ cd ai-workshop
 > [!NOTE]
 > The AI Web Chat template (`dotnet new aichatweb`) is installed and validated later, in the module where it is first used.
 
-## Step 2: Create a GitHub Account (if needed)
+## Step 2: (Optional) Create a GitHub Account
 
-If you don't already have a GitHub account, follow these steps to create one:
+If you plan to contribute updates back to this repository, create a GitHub account:
 
 1. **Create a GitHub account:**
    - Go to [https://github.com/signup](https://github.com/signup)

--- a/Part 4 - AI Web Chat Template/README.md
+++ b/Part 4 - AI Web Chat Template/README.md
@@ -182,8 +182,7 @@ concept by hand first:
 ## What's next
 
 In **Part 5** you'll make the provider story explicit: [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) as the
-primary, with Foundry Local / Ollama / GitHub Models (legacy) as swap-in
-alternatives — the payoff of everything running on `IChatClient` and
+primary, with Foundry Local / Ollama as swap-in alternatives — the payoff of everything running on `IChatClient` and
 `IEmbeddingGenerator`.
 
 **Continue to** → [Part 5: Providers and Fallbacks](../Part%205%20-%20Providers%20and%20Fallbacks/README.md)

--- a/Part 5 - Providers and Fallbacks/README.md
+++ b/Part 5 - Providers and Fallbacks/README.md
@@ -1,4 +1,4 @@
-# Part 5: Providers & fallbacks (Azure primary; local + legacy)
+# Part 5: Providers & Fallbacks (Azure primary + local)
 
 This is the payoff of the whole workshop theme: **swap the provider, keep the same
 `IChatClient` / `IEmbeddingGenerator`.** Everything you built in Parts 2–4 — the
@@ -6,18 +6,17 @@ chat loop, the RAG loop, the template app — runs unchanged when you point it a
 different model provider. The only thing that changes is *registration* (an
 endpoint, a key, a model name), never your app code.
 
-The real-world motivation: **GitHub Models retires July 30, 2026.** Because the app
-depends on the abstraction and not on a specific provider, surviving that
-retirement is a configuration change, not a rewrite.
+The real-world motivation: your app should be able to change providers without a
+rewrite. Because the app depends on the abstraction and not on a specific provider,
+provider changes become configuration updates.
 
-## The four providers
+## The three providers
 
 | Provider | Best for | Chat | Embeddings | Runs offline | Notes |
 | --- | --- | :---: | :---: | :---: | --- |
 | **[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)** (Azure OpenAI) | **Primary** — the workshop default | ✅ | ✅ | ❌ | `gpt-5-mini` + `text-embedding-3-small` |
 | **Foundry Local** | Local **chat** on your device | ✅ | ⏳ | ✅ | OpenAI-compatible local server; SLMs (Phi, Qwen, …). Embedding support is being evaluated (#496) |
 | **Ollama** | Fully **offline RAG** (chat + embeddings) | ✅ | ✅ | ✅ | e.g. `llama3.2` for chat, `all-minilm` for embeddings |
-| **GitHub Models** (legacy) | Zero-setup dev/demo | ✅ | ⚠️ | ❌ | **Retires 2026-07-30** (brownouts July 16 & 23) |
 
 ## Provider 1: [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (primary)
 
@@ -36,9 +35,9 @@ IEmbeddingGenerator<string, Embedding<float>> embeddings =
 
 ## The universal pattern for everything else
 
-Foundry Local, Ollama, and GitHub Models **all** expose an **OpenAI-compatible**
-endpoint. That means all three use the *same* client — `OpenAIClient` — pointed at
-a different base URL and key:
+Foundry Local and Ollama both expose an **OpenAI-compatible** endpoint. That means
+both use the *same* client — `OpenAIClient` — pointed at a different base URL and
+key:
 
 ```csharp
 using OpenAI;
@@ -116,25 +115,6 @@ IEmbeddingGenerator<string, Embedding<float>> embeddings =
 Swap these two into your Part 3 project and the entire embed → store → search →
 augment loop runs with no cloud at all.
 
-## Provider 4: GitHub Models (legacy)
-
-GitHub Models gave free, zero-setup access during development. It uses the same
-universal pattern with a GitHub token as the key:
-
-```csharp
-var client = new OpenAIClient(
-    new ApiKeyCredential(githubToken),
-    new OpenAIClientOptions { Endpoint = new Uri("https://models.inference.ai.azure.com") });
-IChatClient chat = client.GetChatClient("gpt-4o-mini").AsIChatClient();
-```
-
-> [!WARNING]
-> **GitHub Models retires on July 30, 2026** (with brownouts on July 16 and 23).
-> Do not build new work on it. It's shown here only because you may see it in older
-> samples — and as the concrete reason this whole "swap the provider" design
-> matters. Move to **[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)** (cloud) or **Foundry Local / Ollama**
-> (local).
-
 ## The takeaway
 
 | What changed between providers | Where it lives |
@@ -146,8 +126,7 @@ IChatClient chat = client.GetChatClient("gpt-4o-mini").AsIChatClient();
 
 That's the entire point of `Microsoft.Extensions.AI`: your chat loop, your RAG
 pipeline, and the template app are all written against `IChatClient` and
-`IEmbeddingGenerator`, so the provider becomes a deployment decision — including
-when a provider you relied on goes away.
+`IEmbeddingGenerator`, so the provider becomes a deployment decision.
 
 ## What's next
 

--- a/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/AppHost.cs
+++ b/Part 6 - Deployment/GenAiLab/GenAiLab.AppHost/AppHost.cs
@@ -3,10 +3,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 // You will need to set the connection string to your own value
 // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
 //   cd this-project-directory
-// Primary: Azure AI Foundry (Azure OpenAI)
+// Azure AI Foundry (Azure OpenAI)
 //   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR_RESOURCE_NAME.openai.azure.com/;Key=YOUR_API_KEY"
-// Legacy fallback (GitHub Models, retiring 2026-07-30):
-//   dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-GITHUB-TOKEN"
 var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")

--- a/Part 6 - Deployment/GenAiLab/README.md
+++ b/Part 6 - Deployment/GenAiLab/README.md
@@ -15,21 +15,14 @@ This incompatibility can be addressed by upgrading to Docker Desktop 4.41.1. See
 
 # Configure the AI Model Provider
 
-## Using GitHub Models
+## Using [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI)
 
-> [!WARNING]
-> **GitHub Models is [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (brownouts July 16 & 23). Use it only as a temporary legacy fallback — prefer **[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)** (see the [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) section below).
-
-To use models hosted by GitHub Models, you will need to create a GitHub personal access token. The token should not have any scopes or permissions. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
-
-From the command line, configure your token for this project using .NET User Secrets by running the following commands:
+From the command line, configure your Azure OpenAI connection string for this project using .NET user secrets:
 
 ```sh
 cd GenAiLab.AppHost
-dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://models.inference.ai.azure.com;Key=YOUR-API-KEY"
+dotnet user-secrets set ConnectionStrings:openai "Endpoint=https://YOUR-RESOURCE-NAME.openai.azure.com/;Key=YOUR-API-KEY"
 ```
-
-Learn more about [prototyping with AI models using GitHub Models](https://docs.github.com/github-models/prototyping-with-ai-models).
 
 ## Setting up a local environment for Qdrant
 

--- a/Part 6 - Deployment/README.md
+++ b/Part 6 - Deployment/README.md
@@ -278,7 +278,7 @@ Congratulations! You've completed the AI Web Chat application series (Parts 1-6)
 
 1. ✅ Create AI applications using the AI Web Chat template
 2. ✅ Understand and customize the template code structure
-3. ✅ Migrate from GitHub Models to Azure OpenAI
+3. ✅ Configure Microsoft Foundry (Azure OpenAI) for cloud AI workloads
 4. ✅ Configure provider and fallback strategies for real-world deployments
 5. ✅ Deploy your application to production environments using Azure
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # .NET AI Workshop
 
-Get up to speed quickly with AI app building in .NET! Explore the new .NET AI project templates integrated with Microsoft Extensions for AI (MEAI), [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry), and vector data stores. Learn how to build with [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI) models for both development and production, with GitHub Models and local models (Foundry Local / Ollama) available as fallbacks. Gain hands-on experience building cutting-edge intelligent solutions with state-of-the-art frameworks and best practices.
-
-> [!IMPORTANT]
-> **GitHub Models is [retiring on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)** (with brownouts on July 16 and 23). This workshop uses **[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI)** as the primary provider; GitHub Models appears only as a legacy fallback. See [Part 5 - Providers and Fallbacks](Part%205%20-%20Providers%20and%20Fallbacks/README.md).
+Get up to speed quickly with AI app building in .NET. This workshop covers two tracks: AI application development (Parts 1-6) and MCP server development (Parts 7-9). The AI track uses [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI) as the cloud provider, with local-model options covered in the provider module.
 
 ## Prerequisites
 
@@ -14,7 +11,6 @@ Get up to speed quickly with AI app building in .NET! Explore the new .NET AI pr
 - .NET 10.0 SDK or later
 - Docker Desktop or Podman (required for .NET Aspire orchestration)
 - Azure subscription with access to [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI) — the primary AI provider
-- GitHub account (optional; GitHub Models is a legacy fallback [retiring July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/))
 
 ### Model Context Protocol (Parts 7-9)
 
@@ -30,109 +26,12 @@ Get up to speed quickly with AI app building in .NET! Explore the new .NET AI pr
 
 ## Lab Overview 🧪
 
-The lab consists of a series of hands-on exercises where you'll build an AI-powered web application using the new .NET AI project templates. The application includes:
+The workshop is split into two tracks:
 
-- 🤖 **AI Chatbot**: A conversational interface that can answer questions about products
-- 📋 **Product Catalog**: AI-generated product descriptions and categories
-- 🔍 **Semantic Search**: Vector-based search using document embeddings
-- 🔌 **Integration with [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)**: Use Azure OpenAI models for development and production, with GitHub Models and local models (Foundry Local / Ollama) as fallbacks
+- **AI Application Build Path (Parts 1-6):** Build a minimal chat app, add retrieval, inspect the generated template architecture, configure provider strategy, and deploy.
+- **Model Context Protocol (MCP) Path (Parts 7-9):** Build MCP servers and package/publish them.
 
-## What We're Building
-
-This lab guides you through building a complete AI-powered web application for an outdoor gear company. The application enables users to chat with an AI assistant that has knowledge of the company's product catalog through document ingestion.
-
-### Application Architecture 🏢
-
-```mermaid
-flowchart TD
-    User([User]) <--> WebApp[Web Application<br>Blazor UI]
-    WebApp <--> VectorDB[(Vector Database<br>Qdrant)]
-    WebApp <--> AIChatService[AI Chat Service<br>Microsoft.Extensions.AI]
-    AIChatService <--> AIProvider[AI Provider<br>[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) / GitHub Models legacy]
-    
-    subgraph Data Flow
-        PDFs[Product PDFs] --> Ingestion[Data Ingestion]
-        Ingestion --> Embeddings[Text Embeddings]
-        Ingestion --> ProductData[Product Metadata]
-        Embeddings --> VectorDB
-        ProductData --> VectorDB
-    end
-    
-    classDef webapp fill:#2774AE,stroke:#000,color:#fff
-    classDef aiservice fill:#F58025,stroke:#000,color:#fff
-    classDef database fill:#8A2BE2,stroke:#000,color:#fff
-    classDef dataflow fill:#4CAF50,stroke:#000,color:#fff
-    
-    class WebApp webapp
-    class AIChatService,AIProvider aiservice
-    class VectorDB,ProductDB database
-    class PDFs,Ingestion,Embeddings dataflow
-```
-
-**Architecture Overview** This diagram illustrates the component relationships in our outdoor gear application. The Blazor web application connects with three key components: a vector database for storing embeddings, an AI chat service powered by Microsoft.Extensions.AI, and a product database. The AI functionality is provided by [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI models), with GitHub Models available as a legacy fallback (retiring July 30, 2026). The data flow shows how product PDFs are ingested, transformed into embeddings, and stored in the vector database to enable contextual AI responses.
-
-### Component Interaction 🔄
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant UI as Blazor UI
-    participant Service as Product Service
-    participant AI as AI Model
-    participant DB as Vector Database
-    
-    User->>UI: Ask question about product
-    UI->>Service: Query product information
-    Service->>AI: Generate embeddings
-    AI-->>Service: Return embeddings
-    Service->>DB: Search similar vectors
-    DB-->>Service: Return relevant documents
-    Service->>AI: Generate response with context
-    AI-->>Service: Return AI response
-    Service-->>UI: Display response to user
-```
-
-**Sequence Overview** This diagram demonstrates the interaction flow when a user queries the system. When a customer asks about a product, their question is processed by the UI and passed to the Product Service. The AI model generates text embeddings for the query, which are then used to search the Vector Database for relevant documents. Once matching information is found, both the original question and retrieved context are sent to the AI model to generate a contextually informed response. This response is then returned through the service layer to the UI for display to the user.
-
-### Development to Production Flow 🚀
-
-```mermaid
-flowchart LR
-    Dev[Development<br>[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)] --> Prod[Production<br>[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry)]
-    Local[Local Vector DB<br>Qdrant] --> Cloud[Cloud Vector DB<br>Qdrant]
-    
-    subgraph Development Environment
-        Dev
-        Local
-    end
-    
-    subgraph Production Environment
-        Prod
-        Cloud
-        ACA[Azure Container Apps]
-    end
-    
-    classDef devnode fill:#2774AE,stroke:#000,color:#fff
-    classDef prodnode fill:#F58025,stroke:#000,color:#fff
-    classDef dbnode fill:#8A2BE2,stroke:#000,color:#fff
-    
-    class Dev,ACA devnode
-    class Prod prodnode
-    class Local,Cloud dbnode
-```
-
-**Development to Production Pathway** This diagram illustrates the transition path from a local development environment to production deployment. During development, you'll use GitHub Models and a local vector database, which provides a cost-effective environment for experimentation and testing. In production, the application transitions to Azure OpenAI for enterprise-grade AI capabilities, Qdrant for scalable vector storage, and Azure Container Apps for a scalable, managed cloud hosting environment. This migration path enables seamless transition while maintaining architectural consistency.
-
-Throughout this lab, you'll implement each part of this architecture, from setting up the AI chat interface to building the product catalog and finally deploying to Azure.
-
-## Key Technologies 🛠️
-
-- 🔷 **.NET 10**: The latest version of .NET
-- 🧠 **Microsoft Extensions for AI (MEAI)**: Libraries for integrating AI capabilities into .NET applications
-- 🔥 **Blazor**: For building interactive web UIs
-- 🌐 **.NET Aspire**: For orchestrating cloud-native distributed applications
-- ☁️ **Azure OpenAI**: Enterprise-grade AI models for production
-- 🔮 **Qdrant Vector Database**: For storing and searching vector embeddings
+Detailed architecture and sequence diagrams are documented in the individual module READMEs where each concept is implemented.
 
 ## Getting Started
 
@@ -173,7 +72,7 @@ This sequence starts with a minimal console chat app, then layers in RAG, templa
 The repository is structured as follows:
 
 - 📖 `Part 1 - Setup` through `Part 9 - MCP Publishing`: Contains all the lab instructions, documentation, and working code snapshots
-- � `manuals/`: Product documentation PDFs for the AI chatbot to reference
+- 📄 `manuals/`: Product documentation PDFs for the AI chatbot exercises
 - 🧪 `docs/testing/`: Testing procedures and validation reports
 
 ## Session Resources 📚
@@ -204,11 +103,10 @@ cd ai-workshop
 
 This script will prompt you for:
 
-- **GitHub Token**: For GitHub Models access (fine-grained token with **Models: Read-only** permission)
 - **Azure OpenAI Endpoint**: Your Azure OpenAI service endpoint URL
 - **Azure OpenAI Key**: Your Azure OpenAI service API key
 
-The credentials are saved as environment variables (`WORKSHOP_GITHUB_TOKEN`, `WORKSHOP_AZURE_OPENAI_ENDPOINT`, `WORKSHOP_AZURE_OPENAI_KEY`) and will be available for subsequent testing sessions.
+The credentials are saved as environment variables (`WORKSHOP_AZURE_OPENAI_ENDPOINT`, `WORKSHOP_AZURE_OPENAI_KEY`) and will be available for subsequent testing sessions.
 
 ### Testing Procedure
 


### PR DESCRIPTION
This pull request removes support for GitHub Models as an AI provider across the workshop, making Microsoft Foundry (Azure OpenAI) the primary and only supported cloud provider for the main workshop flow. All instructions, scripts, and documentation have been updated to remove references to GitHub Models and the associated token setup, simplifying the onboarding and focusing on Azure OpenAI credentials. Local model options (Foundry Local, Ollama) remain as offline alternatives. The changes also clarify that a GitHub account is now optional and only needed for contributor workflows.

**Provider and credential changes:**

* Removed all references to GitHub Models as a provider and as a credential requirement in documentation, setup scripts, and instructions. Now only Azure OpenAI (Microsoft Foundry) and local models are supported. (`.github/copilot-instructions.md`, `.github/prompts/test-workshop.prompt.md`, `.github/scripts/setup-workshop-credentials.ps1`, `.github/.devcontainer/README.md`, `Part 1 - Setup/README.md`) [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L5-R5) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L84-R84) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L100-R100) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L146-R147) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L160-R160) [[6]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L96) [[7]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L115-R124) [[8]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L154-R151) [[9]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L199-R196) [[10]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L231-R228) [[11]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L386) [[12]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L419-R415) [[13]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L8) [[14]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L30-L50) [[15]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L188-R173) [[16]](diffhunk://#diff-eaa43fa9635876856ab6b5eb805dab32ee74b5fecc7eb388c412b4d2d472c7d3L21) [[17]](diffhunk://#diff-eaa43fa9635876856ab6b5eb805dab32ee74b5fecc7eb388c412b4d2d472c7d3L36-L37) [[18]](diffhunk://#diff-9f1f313f729d73c41cbd078a26d0a2a7778ec1f984e3dd53821d6603dcc09c0cL9-L11) [[19]](diffhunk://#diff-9f1f313f729d73c41cbd078a26d0a2a7778ec1f984e3dd53821d6603dcc09c0cL21-R18) [[20]](diffhunk://#diff-9f1f313f729d73c41cbd078a26d0a2a7778ec1f984e3dd53821d6603dcc09c0cL98-R97) [[21]](diffhunk://#diff-685010a547fe0a348871327003278d6c62e39886be7eb1ac2e6ce61d32a9388cL185-R185)

**Script and workflow simplification:**

* The PowerShell setup script no longer checks for or prompts for a GitHub Models token; it now only manages Azure OpenAI credentials and related Azure environment variables. (`.github/scripts/setup-workshop-credentials.ps1`) [[1]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L8) [[2]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L30-L50) [[3]](diffhunk://#diff-7b25996d6af6064f2734b5ab70c12d797fac4d663a43b5ea50af99fad029c920L188-R173) [[4]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L386)

**Documentation and template updates:**

* All template generation instructions, validation steps, and test prompts now use `--provider azureopenai` instead of `githubmodels`, and the requirement for a GitHub token has been removed. (`.github/copilot-instructions.md`, `.github/prompts/test-workshop.prompt.md`) [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L100-R100) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L154-R151) [[3]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L199-R196) [[4]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L231-R228) [[5]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L419-R415)
* The devcontainer and setup documentation now clarify that a GitHub account is optional (for contributor workflows), and that GitHub Models is no longer a supported provider. (`.github/.devcontainer/README.md`, `Part 1 - Setup/README.md`) [[1]](diffhunk://#diff-eaa43fa9635876856ab6b5eb805dab32ee74b5fecc7eb388c412b4d2d472c7d3L21) [[2]](diffhunk://#diff-eaa43fa9635876856ab6b5eb805dab32ee74b5fecc7eb388c412b4d2d472c7d3L36-L37) [[3]](diffhunk://#diff-9f1f313f729d73c41cbd078a26d0a2a7778ec1f984e3dd53821d6603dcc09c0cL21-R18) [[4]](diffhunk://#diff-9f1f313f729d73c41cbd078a26d0a2a7778ec1f984e3dd53821d6603dcc09c0cL98-R97)
* Provider fallback documentation now lists only Foundry Local and Ollama as alternatives to Microsoft Foundry, removing GitHub Models as a fallback. (`Part 4 - AI Web Chat Template/README.md`)