### PR TITLE
chore: skip dotnet build for markdown PRs in dotnet-build.yml

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -5,18 +5,37 @@ on:
     branches:
       - main
     paths:
-      - 'Part 2 - Build Chat App/**'
-      - 'Part 6 - Deployment/**'
-      - 'Part 7 - MCP Server Basics/**'
-      - 'Part 8 - Enhanced MCP Server/**'
+      - "Part 2 - Build Chat App/**"
+      - "Part 6 - Deployment/**"
+      - "Part 7 - MCP Server Basics/**"
+      - "Part 8 - Enhanced MCP Server/**"
   pull_request:
     branches:
       - main
     paths:
-      - 'Part 2 - Build Chat App/**'
-      - 'Part 6 - Deployment/**'
-      - 'Part 7 - MCP Server Basics/**'
-      - 'Part 8 - Enhanced MCP Server/**'
+      - ".github/workflows/dotnet-build.yml"
+      - "Part 2 - Build Chat App/**/*.cs"
+      - "Part 2 - Build Chat App/**/*.razor"
+      - "Part 2 - Build Chat App/**/*.csproj"
+      - "Part 2 - Build Chat App/**/*.sln"
+      - "Part 2 - Build Chat App/**/*.props"
+      - "Part 2 - Build Chat App/**/*.targets"
+      - "Part 6 - Deployment/**/*.cs"
+      - "Part 6 - Deployment/**/*.razor"
+      - "Part 6 - Deployment/**/*.csproj"
+      - "Part 6 - Deployment/**/*.sln"
+      - "Part 6 - Deployment/**/*.props"
+      - "Part 6 - Deployment/**/*.targets"
+      - "Part 7 - MCP Server Basics/**/*.cs"
+      - "Part 7 - MCP Server Basics/**/*.csproj"
+      - "Part 7 - MCP Server Basics/**/*.sln"
+      - "Part 7 - MCP Server Basics/**/*.props"
+      - "Part 7 - MCP Server Basics/**/*.targets"
+      - "Part 8 - Enhanced MCP Server/**/*.cs"
+      - "Part 8 - Enhanced MCP Server/**/*.csproj"
+      - "Part 8 - Enhanced MCP Server/**/*.sln"
+      - "Part 8 - Enhanced MCP Server/**/*.props"
+      - "Part 8 - Enhanced MCP Server/**/*.targets"
   workflow_dispatch:
 
 jobs:
@@ -27,27 +46,27 @@ jobs:
       matrix:
         include:
           - solution: "Part 2 - Build Chat App/ChatApp/ChatApp.csproj"
-            dotnet-version: '10.0.x'
+            dotnet-version: "10.0.x"
           - solution: "Part 6 - Deployment/GenAiLab/GenAiLab.sln"
-            dotnet-version: '10.0.x'
+            dotnet-version: "10.0.x"
           # No solution file exists for MyMcpServer; using project file directly
           - solution: "Part 7 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj"
-            dotnet-version: '10.0.x'
+            dotnet-version: "10.0.x"
           # No solution file exists for ContosoOrdersMcpServer; using project file directly
           - solution: "Part 8 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj"
-            dotnet-version: '10.0.x'
+            dotnet-version: "10.0.x"
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
 
-    - name: Restore dependencies
-      run: dotnet restore "${{ matrix.solution }}"
+      - name: Restore dependencies
+        run: dotnet restore "${{ matrix.solution }}"
 
-    - name: Build solution
-      run: dotnet build "${{ matrix.solution }}" --no-restore --configuration Release
+      - name: Build solution
+        run: dotnet build "${{ matrix.solution }}" --no-restore --configuration Release

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/dotnet-build.yml"
       - "Part 2 - Build Chat App/**"
       - "Part 6 - Deployment/**"
       - "Part 7 - MCP Server Basics/**"
@@ -17,7 +18,6 @@ on:
       - "Part 2 - Build Chat App/**/*.cs"
       - "Part 2 - Build Chat App/**/*.razor"
       - "Part 2 - Build Chat App/**/*.csproj"
-      - "Part 2 - Build Chat App/**/*.sln"
       - "Part 2 - Build Chat App/**/*.props"
       - "Part 2 - Build Chat App/**/*.targets"
       - "Part 6 - Deployment/**/*.cs"
@@ -28,12 +28,10 @@ on:
       - "Part 6 - Deployment/**/*.targets"
       - "Part 7 - MCP Server Basics/**/*.cs"
       - "Part 7 - MCP Server Basics/**/*.csproj"
-      - "Part 7 - MCP Server Basics/**/*.sln"
       - "Part 7 - MCP Server Basics/**/*.props"
       - "Part 7 - MCP Server Basics/**/*.targets"
       - "Part 8 - Enhanced MCP Server/**/*.cs"
       - "Part 8 - Enhanced MCP Server/**/*.csproj"
-      - "Part 8 - Enhanced MCP Server/**/*.sln"
       - "Part 8 - Enhanced MCP Server/**/*.props"
       - "Part 8 - Enhanced MCP Server/**/*.targets"
   workflow_dispatch:
@@ -58,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet-build.yml` workflow configuration to improve path specificity and consistency for build triggers, and to standardize formatting.

**Workflow trigger improvements:**

* The `pull_request` trigger now only runs when relevant source files (`.cs`, `.razor`, `.csproj`, `.sln`, `.props`, `.targets`) or the workflow file itself are changed, reducing unnecessary workflow runs.
* The `push` and `pull_request` path patterns have been updated to use double quotes for consistency and to avoid YAML parsing issues.

**Formatting and consistency:**

* The `dotnet-version` values in the job matrix are now consistently quoted with double quotes instead of single quotes, improving YAML style and consistency.