### PR TITLE
Fix Part 11 docs, align package versions, add Part 7 namespace

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ CI (`.github/workflows/dotnet-build.yml`) restores and builds these seven target
 "Part 11 - Deployment/GenAiLab/GenAiLab.sln" | ForEach-Object { dotnet build $_ -c Release }
 ```
 
-Expected warnings: Part 7 emits 3 × CS1998 (async tool methods with no `await`). These are intentional — the async signature is kept for API consistency.
+All seven targets build clean — zero warnings. Treat any new warning as a regression.
 
 Markdown is linted by `.github/workflows/markdownlint.yml` using `.markdownlint.json`.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,11 @@ updates:
   - package-ecosystem: "nuget"
     directories:
       - "/Part 2 - Build Chat App/ChatApp/"
+      - "/Part 3 - Add RAG/RagChatApp/"
       - "/Part 11 - Deployment/GenAiLab/"
       - "/Part 6 - MCP Server Basics/MyMcpServer/"
       - "/Part 7 - Enhanced MCP Server/ContosoOrdersMcpServer/"
+      - "/Part 9 - Agent Framework Basics/AgentApp/"
       - "/Part 10 - Adding AI to an Existing App/StoreApp/"
     schedule:
       interval: "weekly"

--- a/.github/skills/workshop-testing/SKILL.md
+++ b/.github/skills/workshop-testing/SKILL.md
@@ -50,7 +50,7 @@ The samples hardcode the deployment names `gpt-5-mini` and `text-embedding-3-sma
 
 An MCP server is a stdio process — it starts and waits. Check:
 
-1. `dotnet build` succeeds (Part 7 legitimately emits 3 × CS1998).
+1. `dotnet build` succeeds with no warnings.
 2. `dotnet run` logs `Server (stream) (<Name>) transport reading messages`.
 3. Ctrl+C shuts it down cleanly.
 4. *Optional:* register it in `.vscode/mcp.json` and confirm the tools appear in Copilot Chat.

--- a/Part 11 - Deployment/README.md
+++ b/Part 11 - Deployment/README.md
@@ -4,7 +4,7 @@
 
 ## In this workshop
 
-In this final part, you will learn how to deploy the AI Web Chat application you scaffolded in [Part 4](../Part%204%20-%20AI%20Web%20Chat%20Template/README.md) to Azure using the Azure Developer CLI (`azd`). You'll deploy your PostgreSQL-based application to Azure Container Apps for production use.
+In this final part, you will learn how to deploy the AI Web Chat application you scaffolded in [Part 4](../Part%204%20-%20AI%20Web%20Chat%20Template/README.md) to Azure using the Azure Developer CLI (`azd`). You'll deploy your Qdrant-backed application to Azure Container Apps for production use.
 
 > [!NOTE]
 > This part deliberately returns to the **Part 4 web application** rather than the console samples from Parts 6-10. Deployment is a property of a hosted application, and the Aspire-orchestrated web app is the realistic thing to ship — it has a front end, a vector store, and service dependencies that have to exist in Azure. The MCP servers, the agent sample, and the capstone `StoreApp` are console applications you run locally; what you learn here about `azd` and Container Apps applies to hosting any of them later.
@@ -13,7 +13,7 @@ In this final part, you will learn how to deploy the AI Web Chat application you
 
 ## Configure the web application for external access
 
-  Before the web application is deployed to Azure Container Apps, you will need to configure it so that it is available via web browser. Update **AppHost** `Program.cs` to add the following line just before the call to `builder.Build().Run();` at the end of the file:
+  Before the web application is deployed to Azure Container Apps, you will need to configure it so that it is available via web browser. Update `GenAiLab.AppHost/AppHost.cs` to add the following line just before the call to `builder.Build().Run();` at the end of the file:
 
   ```csharp
   webApp.WithExternalHttpEndpoints();

--- a/Part 3 - Add RAG/RagChatApp/RagChatApp.csproj
+++ b/Part 3 - Add RAG/RagChatApp/RagChatApp.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Part 7 - Enhanced MCP Server/ContosoOrdersMcpServer/Program.cs
+++ b/Part 7 - Enhanced MCP Server/ContosoOrdersMcpServer/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ContosoOrdersMcpServer.Tools;
 
 var builder = Host.CreateApplicationBuilder(args);
 

--- a/Part 7 - Enhanced MCP Server/ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs
+++ b/Part 7 - Enhanced MCP Server/ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs
@@ -2,6 +2,8 @@ using System.ComponentModel;
 using System.Text.Json;
 using ModelContextProtocol.Server;
 
+namespace ContosoOrdersMcpServer.Tools;
+
 /// <summary>
 /// ContosoOrders business tools for demonstration purposes.
 /// These tools can be invoked by MCP clients to interact with the Contoso business system.

--- a/Part 7 - Enhanced MCP Server/README.md
+++ b/Part 7 - Enhanced MCP Server/README.md
@@ -59,7 +59,7 @@ Open `ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs` and examine the three 
 ```csharp
 [McpServerTool]
 [Description("Retrieves order information from the Contoso business system.")]
-public async Task<string> GetOrderDetails(
+public string GetOrderDetails(
     [Description("The order ID to look up")] string orderId)
 ```
 
@@ -70,7 +70,7 @@ public async Task<string> GetOrderDetails(
 ```csharp
 [McpServerTool]
 [Description("Searches for orders by customer name.")]
-public async Task<string> SearchOrdersByCustomer(
+public string SearchOrdersByCustomer(
     [Description("Customer name to search for")] string customerName)
 ```
 
@@ -81,7 +81,7 @@ public async Task<string> SearchOrdersByCustomer(
 ```csharp
 [McpServerTool]
 [Description("Gets inventory status for a specific product.")]
-public async Task<string> GetProductInventory(
+public string GetProductInventory(
     [Description("Product name or SKU to check inventory for")] string productName)
 ```
 

--- a/Part 9 - Agent Framework Basics/AgentApp/AgentApp.csproj
+++ b/Part 9 - Agent Framework Basics/AgentApp/AgentApp.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cleanup pass covering three defects found during the recent instructions/skill review, plus two things that turned up while fixing them.

## Part 11 README

- "deploy your PostgreSQL-based application" → "Qdrant-backed application". The app has used Qdrant since Part 4; the PostgreSQL wording was left over from an earlier version of the lab.
- "Update **AppHost** `Program.cs`" → "Update `GenAiLab.AppHost/AppHost.cs`". The file was renamed by the Aspire template and the instruction sent attendees looking for a file that doesn't exist.

The other `Program.cs` reference further down is correct and untouched — that one is the Azure AI Search alternative, which really does edit `GenAiLab.Web/Program.cs`.

## Package version alignment

Parts 3 and 9 were behind everything else:

| Package | Was | Now |
| --- | --- | --- |
| `Microsoft.Extensions.AI` | 10.7.0 | 10.8.1 |
| `Microsoft.Extensions.AI.OpenAI` | 10.7.0 | 10.8.1 |
| `Microsoft.Extensions.Configuration.UserSecrets` | 10.0.9 | 10.0.10 |
| `Microsoft.Agents.AI` (Part 9) | 1.0.0 | 1.15.0 |

**Root cause:** `.github/dependabot.yml` only listed Parts 2, 6, 7, 10, and 11 in its `directories:` block. Parts 3 and 9 were never being bumped, which is exactly why they were the two that fell behind. Both are now added, so this shouldn't re-accumulate.

Part 11's `Azure.AI.OpenAI 2.3.0-beta.2` is deliberately left as-is. That's not drift — it's what `dotnet new aichatweb` emits, and `Aspire.Azure.AI.OpenAI 9.5.0-preview` depends on it. Pinning it back to 2.1.0 would diverge from the template output attendees generate in Part 4.

## Part 7 namespace

`ContosoOrdersTools.cs` had no namespace while Part 6's tools use `namespace MyMcpServer.Tools;`. Added `namespace ContosoOrdersMcpServer.Tools;` and the matching `using` in `Program.cs`.

## Two things found along the way

**Part 7 README didn't match its snapshot.** The "examine the file" section showed all three tools as `public async Task<string>`, but the snapshot code is synchronous. Corrected, since the repo convention is that snapshots and READMEs stay in sync. The async examples in the later patterns discussion are illustrative and left alone.

**Stale build expectations.** Both `copilot-instructions.md` and the workshop-testing skill claimed Part 7 emits 3 × CS1998 warnings. It doesn't — the tools stopped being async at some point. Replaced with "builds clean, treat any new warning as a regression." The archived test report still mentions CS1998, which is correct for its date; that file is untouched.

## Validation

All seven CI targets built in Release: `0 Warning(s) 0 Error(s)` across the board.
