### PR TITLE
docs: fix rendering and stale references found reviewing the renumber

### DIFF
--- a/Part 05 - MCP Server Basics/README.md
+++ b/Part 05 - MCP Server Basics/README.md
@@ -81,7 +81,7 @@ The MCP server template is included in the `Microsoft.Extensions.AI.Templates` p
      -o, --output <output>       Location to place the generated output...
    ```
 
-   > **Note**: If you get an error that the template is not found, make sure you have .NET 10.0 SDK (preview 6 or higher) installed and the templates were installed correctly in Part 2. You can reinstall with: `dotnet new install Microsoft.Extensions.AI.Templates`
+   > **Note**: If you get an error that the template is not found, make sure you have .NET 10.0 SDK (preview 6 or higher) installed and the templates were installed correctly in Part 4. You can reinstall with: `dotnet new install Microsoft.Extensions.AI.Templates`
 
 ## Step 2: Create Your First MCP Server
 

--- a/Part 05 - MCP Server Basics/README.md
+++ b/Part 05 - MCP Server Basics/README.md
@@ -81,7 +81,7 @@ The MCP server template is included in the `Microsoft.Extensions.AI.Templates` p
      -o, --output <output>       Location to place the generated output...
    ```
 
-   > **Note**: If you get an error that the template is not found, make sure you have .NET 10.0 SDK (preview 6 or higher) installed and the templates were installed correctly in Part 4. You can reinstall with: `dotnet new install Microsoft.Extensions.AI.Templates`
+   > **Note**: If you get an error that the template is not found, make sure you have the .NET 10.0 SDK or later installed and the templates were installed correctly in Part 4. You can reinstall with: `dotnet new install Microsoft.Extensions.AI.Templates`
 
 ## Step 2: Create Your First MCP Server
 

--- a/Part 07 - MCP Publishing/README.md
+++ b/Part 07 - MCP Publishing/README.md
@@ -246,10 +246,10 @@ Can you give me a 5-day forecast for London?
 ```json
 {
   "servers": {
-    "WeatherMcpServer": {
+    "MyMcpServer": {
       "type": "stdio", 
       "command": "dnx",
-      "args": ["YourName.WeatherMcpServer", "--version", "1.0.0"],
+      "args": ["YourName.MyMcpServer", "--version", "1.0.0"],
       "env": {
         "WEATHER_UNITS": "fahrenheit"
       }
@@ -407,11 +407,11 @@ Expected contents:
 ```json
 {
   "servers": {
-    "WeatherMcpServer": {
+    "MyMcpServer": {
       "type": "stdio",
       "command": "dnx",
       "args": [
-        "CompanyName.WeatherMcpServer",
+        "CompanyName.MyMcpServer",
         "--source",
         "https://pkgs.dev.azure.com/company/_packaging/mcp-servers/nuget/v3/index.json",
         "--version", 
@@ -506,10 +506,10 @@ public class WeatherTools
 ```json
 {
   "servers": {
-    "WeatherMcpServer": {
+    "MyMcpServer": {
       "type": "stdio",
       "command": "dnx",
-      "args": ["YourName.WeatherMcpServer"],
+      "args": ["YourName.MyMcpServer"],
       "env": {
         "WEATHER_API_KEY": "${env:WEATHER_API_KEY}"
       }
@@ -607,7 +607,7 @@ steps:
   displayName: 'Build Package'
   inputs:
     command: 'pack'
-    packagesToPack: '**/WeatherMcpServer.csproj'
+    packagesToPack: '**/MyMcpServer.csproj'
     configuration: 'Release'
 
 - task: NuGetCommand@2
@@ -623,23 +623,23 @@ steps:
 
 ```dockerfile
 # Dockerfile for containerized MCP server
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
-COPY ["WeatherMcpServer.csproj", "."]
-RUN dotnet restore "WeatherMcpServer.csproj"
+COPY ["MyMcpServer.csproj", "."]
+RUN dotnet restore "MyMcpServer.csproj"
 COPY . .
-RUN dotnet build "WeatherMcpServer.csproj" -c Release -o /app/build
+RUN dotnet build "MyMcpServer.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "WeatherMcpServer.csproj" -c Release -o /app/publish
+RUN dotnet publish "MyMcpServer.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "WeatherMcpServer.dll"]
+ENTRYPOINT ["dotnet", "MyMcpServer.dll"]
 ```
 
 ## Step 10: Documentation and Support

--- a/Part 10 - Choosing Providers and Services/README.md
+++ b/Part 10 - Choosing Providers and Services/README.md
@@ -164,7 +164,7 @@ specific store.
 
 Part 11 deploys the Qdrant path, because it is the one you have been running all
 day and it needs no extra provisioning. If you want the managed option instead,
-the swap is a registration change in two files rather than a rewrite \u2014 see
+the swap is a registration change in two files rather than a rewrite — see
 [Optional: using a managed vector store](../Part%2011%20-%20Deployment/README.md#optional-using-a-managed-vector-store)
 in the next part.
 
@@ -173,8 +173,8 @@ in the next part.
 You have made the two decisions that deployment depends on: which provider serves
 the model, and which service stores the vectors. Now put it in Azure.
 
-**Continue to** \u2192 [Part 11: Deploy to Azure](../Part%2011%20-%20Deployment/README.md)
+**Continue to** → [Part 11: Deploy to Azure](../Part%2011%20-%20Deployment/README.md)
 
 ---
 
-\ud83d\udcd6 **Return to**: [Workshop Overview](../README.md) | \ud83d\udd04 **Previous**: [Part 9: Adding AI to an Existing App](../Part%2009%20-%20Adding%20AI%20to%20an%20Existing%20App/README.md) | \u27a1\ufe0f **Next**: [Part 11: Deploy to Azure](../Part%2011%20-%20Deployment/README.md)
+📖 **Return to**: [Workshop Overview](../README.md) | 🔄 **Previous**: [Part 9: Adding AI to an Existing App](../Part%2009%20-%20Adding%20AI%20to%20an%20Existing%20App/README.md) | ➡️ **Next**: [Part 11: Deploy to Azure](../Part%2011%20-%20Deployment/README.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Get up to speed quickly with AI app building in .NET. This workshop covers AI ap
 ### AI Web Chat Application Requirements (Parts 1-4, 10, and 11)
 
 - Visual Studio 2026 or VS Code
-- .NET AI Web Chatbot template installed (instructions in Part 1 - Setup)
+- .NET AI Web Chatbot template installed (`dotnet new install Microsoft.Extensions.AI.Templates`; walked through in Part 4)
 - .NET 10.0 SDK or later
 - Docker Desktop or Podman (recommended for the full Qdrant + Aspire path in Part 4)
 - Azure subscription with access to [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI), the primary AI provider
@@ -63,6 +63,9 @@ The workshop is designed as a **two-part, roughly 8-hour hands-on lab** (8:30-5:
 
 > [!IMPORTANT]
 > **If you fall behind, cut Parts 10-11 (deployment preparation and deployment) — not Part 9 (the capstone).** Deployment is placed last deliberately: nothing depends on it, and it is the most environment-fragile section (Azure login, subscription and quota checks, provisioning time). Part 10 exists to set up the deployment, so if there is no time to deploy there is little reason to spend time choosing what to deploy to. The capstone is where the whole workshop comes together, so protect that time first. A short `azd up` walkthrough by the instructor is a reasonable substitute for a room that has run out of clock.
+
+<!-- -->
+
 > [!TIP]
 > The morning is the tighter half. Ask attendees to complete [Part 1 - Setup](Part%2001%20-%20Setup/README.md) **before** the session — it is prerequisite installation rather than lab content, and moving it to pre-work buys back 15-20 minutes at exactly the point in the day where the schedule has the least slack.
 
@@ -120,7 +123,7 @@ The repository is structured as follows:
 
 - 📖 `Part 01 - Setup` through `Part 11 - Deployment`: Contains all the lab instructions, documentation, and working code snapshots
 - 📄 `manuals/`: Product documentation PDFs for the AI chatbot exercises
-- 🧪 `docs/testing/`: Testing procedures and validation reports
+- 🧪 `docs/`: Instructor guides, testing procedures, and archived reports
 
 ## Session Resources 📚
 

--- a/docs/instructor/MCP_INSTRUCTOR_GUIDE.md
+++ b/docs/instructor/MCP_INSTRUCTOR_GUIDE.md
@@ -126,7 +126,7 @@ flowchart TD
 
 1. **Project Creation** (5 minutes)
    - Navigate to Part 5 directory
-   - Examine WeatherMcpServer project structure
+   - Examine MyMcpServer project structure
    - Discuss project template and dependencies
 
 2. **Code Exploration** (15 minutes)
@@ -142,7 +142,7 @@ flowchart TD
 #### **VS Code Integration (10 minutes)**
 
 1. **MCP Configuration** - Create `.vscode/mcp.json`
-2. **Server Registration** - Add WeatherMcpServer configuration
+2. **Server Registration** - Add MyMcpServer configuration
 3. **VS Code Restart** - Refresh MCP server discovery
 
 #### **Testing and Validation (10 minutes)**

--- a/docs/planning/MCP_TESTING_GUIDE.md
+++ b/docs/planning/MCP_TESTING_GUIDE.md
@@ -46,14 +46,14 @@ Before testing MCP functionality, verify all prerequisites are met:
 
 ### Test 1: Project Build Verification
 
-**Objective**: Verify the WeatherMcpServer project builds successfully
+**Objective**: Verify the MyMcpServer project builds successfully
 
 **Steps**:
 
 1. Navigate to the Part 5 project directory:
 
    ```powershell
-   cd "Part 05 - MCP Server Basics\WeatherMcpServer"
+   cd "Part 05 - MCP Server Basics\MyMcpServer"
    ```
 
 2. Build the project:
@@ -87,7 +87,7 @@ Before testing MCP functionality, verify all prerequisites are met:
      "servers": {
        "weather-server": {
          "command": "dnx",
-         "args": ["run", "--project", "./Part 05 - MCP Server Basics/WeatherMcpServer"]
+         "args": ["run", "--project", "./Part 05 - MCP Server Basics/MyMcpServer"]
        }
      }
    }
@@ -197,7 +197,7 @@ Before testing MCP functionality, verify all prerequisites are met:
      "servers": {
        "weather-server": {
          "command": "dnx",
-         "args": ["run", "--project", "./Part 05 - MCP Server Basics/WeatherMcpServer"]
+         "args": ["run", "--project", "./Part 05 - MCP Server Basics/MyMcpServer"]
        },
        "contoso-orders": {
          "command": "dnx",
@@ -373,7 +373,7 @@ Before testing MCP functionality, verify all prerequisites are met:
 
 ```powershell
 # Verify server can start manually
-cd "Part 05 - MCP Server Basics\WeatherMcpServer"
+cd "Part 05 - MCP Server Basics\MyMcpServer"
 dnx run
 ```
 


### PR DESCRIPTION
Follow-up to #553. Fixes found while reviewing the reorder/renumber.

## Rendering bugs

**Literal `\uXXXX` escapes in [Part 10 - Choosing Providers and Services/README.md](https://github.com/dotnet-presentations/ai-workshop/blob/main/Part%2010%20-%20Choosing%20Providers%20and%20Services/README.md).** Three lines contained the escape sequences as text rather than the characters, so readers saw `\u2192` instead of `→` and the entire footer navigation row rendered as `\ud83d\udcd6 **Return to**: … \u27a1\ufe0f **Next**:`.

**Broken alert in [README.md](https://github.com/dotnet-presentations/ai-workshop/blob/main/README.md).** The `> [!TIP]` about moving Part 1 to pre-work had no separator from the preceding `> [!IMPORTANT]`, so the two merged into one blockquote and the TIP marker showed as literal text. Separated with the `<!-- -->` idiom already used in Part 1. (A blank line trips MD028.)

## Stale references

**Template install location.** Part 5 said the templates were installed "in Part 2" on one line and "in Part 4" on another; the root README prerequisite said Part 1. `dotnet new install Microsoft.Extensions.AI.Templates` actually happens in Part 4. Both stale references corrected.

**`WeatherMcpServer` → `MyMcpServer`, 19 occurrences.** No project by that name exists — Part 5 ships `MyMcpServer`.

- `docs/planning/MCP_TESTING_GUIDE.md`: two `cd "Part 05 - MCP Server Basics\WeatherMcpServer"` commands that would have failed outright, two `mcp.json` `--project` paths, one objective line
- `docs/instructor/MCP_INSTRUCTOR_GUIDE.md`: two teaching-flow mentions
- `Part 07 - MCP Publishing/README.md`: twelve, across the VS Code config, enterprise feed config, security config, the Azure Pipelines `packagesToPack` glob, and the Dockerfile. Part 7 already instructed opening `MyMcpServer.csproj` and packing `YourName.MyMcpServer`, so the file contradicted itself.

**Part 7 sample Dockerfile targeted .NET 8.** Bumped `mcr.microsoft.com/dotnet/runtime` and `sdk` to `10.0`, matching the `net10.0` TFM shown 550 lines earlier in the same part. These were the only stale .NET 8/9 references left in the docs.

**`docs/testing/` in Lab Structure** described as holding "testing procedures and validation reports" — it contains only a `.gitkeep`. Changed to `docs/`.

## Validation

- Every relative link and every heading anchor in the repo resolves.
- markdownlint clean using the same invocation as CI.
- Docs only; no code changed.
