### PR TITLE
Part 3: fix the Step 3 ingestion crash and the Windows chunking no-op

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+# The Part 3 lab splits this document on "\n\n". Force LF on checkout so the
+# chunking step behaves the same on Windows as it does on macOS and Linux.
+**/sample-docs/*.md text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto
 
-# The Part 3 lab splits this document on "\n\n". Force LF on checkout so the
-# chunking step behaves the same on Windows as it does on macOS and Linux.
+# The Part 3 lab splits sample-docs/*.md on "\n\n". Force LF on checkout so
+# the chunking step behaves the same on Windows as it does on macOS and Linux.
 **/sample-docs/*.md text eol=lf

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,6 @@
   },
   "MD013": false,
   "MD033": false,
+  "MD034": false,
   "MD041": false
 }

--- a/Part 03 - Add RAG/README.md
+++ b/Part 03 - Add RAG/README.md
@@ -153,12 +153,14 @@ This splits the document into paragraph-sized chunks so the app can search
 smaller pieces instead of treating the whole file as one block of text.
 
 > [!IMPORTANT]
-> `ReplaceLineEndings("\n")` is not optional. On Windows the file is usually
-> checked out with CRLF line endings, so a blank line is `"\r\n\r\n"` and
-> splitting on `"\n\n"` matches nothing. Without it the whole document comes back
-> as a single chunk and the next step prints `Embedding 1 chunks` instead of
-> `Embedding 11 chunks`. The answers still look right, because that one chunk is
-> small enough to always be selected, so the bug is easy to miss.
+> `ReplaceLineEndings("\n")` is important even though this repo's `.gitattributes`
+> forces LF on checkout. On Windows, files created, edited, or copied outside the
+> repo can still arrive with CRLF line endings. If the file has CRLF, a blank line
+> is `"\r\n\r\n"` and splitting on `"\n\n"` matches nothing. Without normalization
+> the whole document comes back as a single chunk and the next step prints
+> `Embedding 1 chunks` instead of `Embedding 11 chunks`. The answers still look
+> right, because that one chunk is small enough to always be selected, so the bug
+> is easy to miss.
 
 ### 2.3 Embed chunks and build a simple in-memory store
 

--- a/Part 03 - Add RAG/README.md
+++ b/Part 03 - Add RAG/README.md
@@ -143,6 +143,7 @@ string docPath = Path.Combine(AppContext.BaseDirectory, "sample-docs", "contoso-
 string document = await File.ReadAllTextAsync(docPath);
 
 string[] chunks = document
+  .ReplaceLineEndings("\n")
   .Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
   .Where(c => c.Length > 0)
   .ToArray();
@@ -150,6 +151,14 @@ string[] chunks = document
 
 This splits the document into paragraph-sized chunks so the app can search
 smaller pieces instead of treating the whole file as one block of text.
+
+> [!IMPORTANT]
+> `ReplaceLineEndings("\n")` is not optional. On Windows the file is usually
+> checked out with CRLF line endings, so a blank line is `"\r\n\r\n"` and
+> splitting on `"\n\n"` matches nothing. Without it the whole document comes back
+> as a single chunk and the next step prints `Embedding 1 chunks` instead of
+> `Embedding 11 chunks`. The answers still look right, because that one chunk is
+> small enough to always be selected, so the bug is easy to miss.
 
 ### 2.3 Embed chunks and build a simple in-memory store
 
@@ -391,16 +400,39 @@ components for reading, splitting, and storing content.
 Add the ingestion loop:
 
 ```csharp
+bool ingestedAnything = false;
+
 await foreach (IngestionResult result in pipeline.ProcessAsync(
   new DirectoryInfo("./sample-docs"),
   searchPattern: "*.md"))
 {
   Console.WriteLine($"Completed processing '{result.DocumentId}'. Succeeded: '{result.Succeeded}'.");
+
+  if (result.Succeeded)
+  {
+    ingestedAnything = true;
+  }
+  else
+  {
+    Console.WriteLine($"  {result.Exception?.Message}");
+  }
+}
+
+if (!ingestedAnything)
+{
+  Console.WriteLine("No documents were ingested, so there is nothing to search. Check the errors above.");
+  return;
 }
 ```
 
 Each markdown file is read, split into smaller pieces, prepared for search, and
 written to `vectors.db`.
+
+Ingestion can fail on a source file the reader can't parse or an unreachable
+embedding endpoint, and `ProcessAsync` reports that through `Succeeded` instead
+of throwing. The guard prints the underlying error and stops. Without it, the
+next step throws `InvalidOperationException: The collection has not been
+initialized yet` and the real cause is buried.
 
 ### 3.5 Keep grounded retrieval and streaming chat
 

--- a/Part 03 - Add RAG/RagChatApp/Program.cs
+++ b/Part 03 - Add RAG/RagChatApp/Program.cs
@@ -64,7 +64,10 @@ IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator =
 string docPath = Path.Combine(AppContext.BaseDirectory, "sample-docs", "contoso-trailblazer-3000.md");
 string document = await File.ReadAllTextAsync(docPath);
 
+// ReplaceLineEndings normalizes CRLF to LF first. Without it, a document checked
+// out with Windows line endings never matches "\n\n" and collapses to one chunk.
 string[] chunks = document
+    .ReplaceLineEndings("\n")
     .Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
     .Where(c => c.Length > 0)
     .ToArray();

--- a/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
+++ b/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
@@ -24,7 +24,7 @@ direct heat; never place the boots on a radiator, as this damages the membrane.
 
 The TrailBlazer 3000 includes a 2-year limited warranty covering manufacturing
 defects. The warranty does not cover normal wear of the sole or damage from
-improper drying. To make a claim, contact <support@contoso.example> with your order
+improper drying. To make a claim, contact support@contoso.example with your order
 number.
 
 ## Return policy

--- a/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
+++ b/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
@@ -24,7 +24,7 @@ direct heat; never place the boots on a radiator, as this damages the membrane.
 
 The TrailBlazer 3000 includes a 2-year limited warranty covering manufacturing
 defects. The warranty does not cover normal wear of the sole or damage from
-improper drying. To make a claim, contact `support@contoso.example` with your order
+improper drying. To make a claim, contact support@contoso.example with your order
 number.
 
 ## Return policy

--- a/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
+++ b/Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md
@@ -24,7 +24,7 @@ direct heat; never place the boots on a radiator, as this damages the membrane.
 
 The TrailBlazer 3000 includes a 2-year limited warranty covering manufacturing
 defects. The warranty does not cover normal wear of the sole or damage from
-improper drying. To make a claim, contact support@contoso.example with your order
+improper drying. To make a claim, contact `support@contoso.example` with your order
 number.
 
 ## Return policy

--- a/Part 03 - Add RAG/checkpoints/manual-program.cs
+++ b/Part 03 - Add RAG/checkpoints/manual-program.cs
@@ -45,7 +45,10 @@ IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator =
 string docPath = Path.Combine(AppContext.BaseDirectory, "sample-docs", "contoso-trailblazer-3000.md");
 string document = await File.ReadAllTextAsync(docPath);
 
+// ReplaceLineEndings normalizes CRLF to LF first. Without it, a document checked
+// out with Windows line endings never matches "\n\n" and collapses to one chunk.
 string[] chunks = document
+    .ReplaceLineEndings("\n")
     .Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
     .Where(c => c.Length > 0)
     .ToArray();

--- a/Part 03 - Add RAG/checkpoints/medi-program.cs
+++ b/Part 03 - Add RAG/checkpoints/medi-program.cs
@@ -60,11 +60,31 @@ using IngestionPipeline<string> pipeline =
     new(reader, chunker, writer, loggerFactory: loggerFactory);
 
 // Ingest the sample markdown docs.
+bool ingestedAnything = false;
+
 await foreach (IngestionResult result in pipeline.ProcessAsync(
     new DirectoryInfo("./sample-docs"),
     searchPattern: "*.md"))
 {
     Console.WriteLine($"Completed processing '{result.DocumentId}'. Succeeded: '{result.Succeeded}'.");
+
+    if (result.Succeeded)
+    {
+        ingestedAnything = true;
+    }
+    else
+    {
+        Console.WriteLine($"  {result.Exception?.Message}");
+    }
+}
+
+// If nothing was ingested the vector store collection was never created, and
+// reading writer.VectorStoreCollection below would throw. Fail with a message
+// that points at the real problem instead.
+if (!ingestedAnything)
+{
+    Console.WriteLine("No documents were ingested, so there is nothing to search. Check the errors above.");
+    return;
 }
 
 // Retrieve from the vector store and answer with grounded chat.


### PR DESCRIPTION
Three defects found in the 2026-07-27 end-to-end run, all in Part 3. Verified against a live Foundry endpoint.

## #567 — Step 3 crashed for every attendee (P0)

`sample-docs/contoso-trailblazer-3000.md` wrote the support address as `<support@contoso.example>`. The angle brackets make Markdig emit an `AutolinkInline`, which the preview MEDI `MarkdownReader` throws on:

```
System.NotSupportedException: Inline type 'AutolinkInline' is not supported.
```

Ingestion reported `Succeeded: False` and the app then crashed on the next statement. Removed the brackets.

## #568 — no guard for failed ingestion (P1)

Step 3.4 now tracks whether anything was ingested, prints `result.Exception?.Message` for failures, and stops:

```csharp
if (!ingestedAnything)
{
  Console.WriteLine("No documents were ingested, so there is nothing to search. Check the errors above.");
  return;
}
```

Without it, `writer.VectorStoreCollection` throws `InvalidOperationException: The collection has not been initialized yet` and the real cause is buried under a stack trace.

## #569 — Step 2 chunking was a silent no-op on Windows (P1)

`Split("\n\n", ...)` never matches a CRLF checkout, so Windows attendees embedded 1 chunk instead of 11. The answers still looked correct, which is why nobody noticed — but chunking, top-k and cosine ranking never actually ran.

Added `ReplaceLineEndings("\n")` before the split, an `[!IMPORTANT]` callout explaining why, and a `.gitattributes` rule pinning `sample-docs/*.md` to LF.

## Files touched

Both the README and the code snapshots plus checkpoints, so they stay in sync.

- `Part 03 - Add RAG/README.md` (Steps 2.2, 3.4)
- `Part 03 - Add RAG/RagChatApp/Program.cs`
- `Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md`
- `Part 03 - Add RAG/checkpoints/manual-program.cs`
- `Part 03 - Add RAG/checkpoints/medi-program.cs`
- `.gitattributes` (new)

## Verification

- `RagChatApp` (Step 2 path) now prints `Embedding 11 chunks from the product guide...` and answers correctly.
- Compiled `checkpoints/medi-program.cs` in a scratch project with the Step 3.1 package list and ran it against live Foundry: ingestion succeeds, `vectors.db` is written, and the warranty question comes back grounded.
- Re-introduced the autolink in the scratch copy to exercise the guard. Output is now the parser error followed by `No documents were ingested, so there is nothing to search.` instead of an unhandled exception.
- `dotnet build -c Release` on `RagChatApp.csproj`: 0 warnings.
- markdownlint: 0 issues.

## Not covered here

#575 (NU1903 warnings on the MEDI path, checkpoints not built by CI) is still open and will be handled separately.

Fixes #567
Fixes #568
Fixes #569
