### PR TITLE
Part 4: put configuration first and make the completed code discoverable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,14 +11,14 @@ Everything targets **.NET 10** and uses **Microsoft Foundry (Azure OpenAI)** as 
 | 01 - Setup | — | README only |
 | 02 - Build Chat App | `ChatApp/` | Console app built by hand (`dotnet new console`) |
 | 03 - Add RAG | `RagChatApp/` | Continues from Part 2; `checkpoints/` holds two alternate `Program.cs` paths (manual cosine similarity, and MEDI + SqliteVec) |
-| 04 - AI Web Chat Template | — | README only; scaffolds `GenAiLab` with `dotnet new aichatweb` |
+| 04 - AI Web Chat Template | *(shares `Part 11 - Deployment/GenAiLab/`)* | README only in this folder; scaffolds `GenAiLab` with `dotnet new aichatweb`. The completed code deliberately lives in Part 11 rather than being duplicated here — keep both READMEs saying so |
 | 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver`; `RandomNumberTools` + `WeatherTools` |
 | 06 - Enhanced MCP Server | `ContosoOrdersMcpServer/` | Optional/bonus. Exploration of an existing snapshot — the README does **not** ask the user to scaffold it |
 | 07 - MCP Publishing | — | Optional/bonus, README only |
 | 08 - Agent Framework Basics | `AgentApp/` | `dotnet new console` + `Microsoft.Agents.AI` |
 | 09 - Adding AI to an Existing App | `eShopLite-start/` and `eShopLite/` (5-project Aspire solutions) | Capstone. `eShopLite-start/` is the AI-free starting point attendees work in; `eShopLite/` is the finished answer key. The workshop adds semantic search, grounded discovery, and a local-model assistant. Added code lives in `Products/Ai/` and `Store/Ai/` |
 | 10 - Choosing Providers and Services | — | README only. Sits immediately before deployment because provider and service selection is a deployment prerequisite |
-| 11 - Deployment | `GenAiLab/` (3-project Aspire solution) | Same app as Part 4 plus `WithExternalHttpEndpoints()` in `AppHost.cs` |
+| 11 - Deployment | `GenAiLab/` (3-project Aspire solution) | Same app as Part 4 plus `WithExternalHttpEndpoints()` in `AppHost.cs`. This is also the answer key for Part 4, so changes here must stay consistent with the Part 4 README |
 
 Other folders: `docs/` (instructor guides, planning, archived test reports), `images/` (screenshots used by workshop instructions), `manuals/` (PDFs used as RAG source data).
 

--- a/.github/scripts/setup-workshop-credentials.ps1
+++ b/.github/scripts/setup-workshop-credentials.ps1
@@ -150,6 +150,8 @@ function Write-WorkshopUserSecrets {
         'Part 02 - Build Chat App/ChatApp'
         'Part 03 - Add RAG/RagChatApp'
         'Part 08 - Agent Framework Basics/AgentApp'
+        'Part 09 - Adding AI to an Existing App/eShopLite-start/Products'
+        'Part 09 - Adding AI to an Existing App/eShopLite-start/Store'
         'Part 09 - Adding AI to an Existing App/eShopLite/Products'
         'Part 09 - Adding AI to an Existing App/eShopLite/Store'
     )
@@ -167,7 +169,7 @@ function Write-WorkshopUserSecrets {
         $ok = (Set-ProjectSecret $project 'AzureOpenAI:Key' $env:WORKSHOP_AZURE_OPENAI_KEY) -and $ok
 
         # Part 9's optional observability assistant can run against a local model.
-        if ($relative -like '*eShopLite/Store' -and $env:WORKSHOP_LOCAL_MODEL_ENDPOINT -and $env:WORKSHOP_LOCAL_MODEL_NAME) {
+        if ($relative -like '*/Store' -and $env:WORKSHOP_LOCAL_MODEL_ENDPOINT -and $env:WORKSHOP_LOCAL_MODEL_NAME) {
             $ok = (Set-ProjectSecret $project 'LocalModel:Endpoint' $env:WORKSHOP_LOCAL_MODEL_ENDPOINT) -and $ok
             $ok = (Set-ProjectSecret $project 'LocalModel:Model' $env:WORKSHOP_LOCAL_MODEL_NAME) -and $ok
         }
@@ -181,11 +183,11 @@ function Write-WorkshopUserSecrets {
         dotnet user-secrets init --project $appHost 2>&1 | Out-Null
         $connection = "Endpoint=$($env:WORKSHOP_AZURE_OPENAI_ENDPOINT);Key=$($env:WORKSHOP_AZURE_OPENAI_KEY)"
         if (Set-ProjectSecret $appHost 'ConnectionStrings:openai' $connection) {
-            Write-Host "  [ok] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost" -ForegroundColor Green
+            Write-Host "  [ok] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost (Parts 4 and 11)" -ForegroundColor Green
         }
     }
     else {
-        Write-Host "  [missing] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost" -ForegroundColor Yellow
+        Write-Host "  [missing] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost (Parts 4 and 11)" -ForegroundColor Yellow
     }
 }
 

--- a/Part 04 - AI Web Chat Template/README.md
+++ b/Part 04 - AI Web Chat Template/README.md
@@ -501,9 +501,9 @@ connection strings and endpoints between them automatically.
 The template also supports a single-project variant that stores vectors in a local
 SQLite file and skips containers entirely. Use this if you cannot run Docker.
 
-Everything in Steps 1-4 applies, but the configuration is different enough that
-the whole path is given here. Read Step 5 as an architecture comparison rather
-than a description of files in your project.
+The same configuration concepts from Steps 1-4 apply, but this scaffold uses
+different files and settings, so the whole path is given here. Read Step 5 as
+an architecture comparison rather than a description of files in your project.
 
 ### Scaffold it
 

--- a/Part 04 - AI Web Chat Template/README.md
+++ b/Part 04 - AI Web Chat Template/README.md
@@ -21,7 +21,26 @@ with production-oriented wiring for persistence and orchestration.
 - [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) with `gpt-5-mini` + `text-embedding-3-small` (see [Part 1](../Part%2001%20-%20Setup/README.md))
 
 > [!NOTE]
-> Docker is not required to learn the core template concepts. If you cannot run containers, use the Docker-free path below. You will still work with the Blazor chat app, dependency injection, ingestion, embeddings, semantic search, and RAG.
+> Docker is not required to learn the core template concepts. If you cannot run
+> containers, use the [Docker-free path](#alternative-docker-free-path-local-vector-store-without-aspire)
+> at the end of this part. You will still work with the Blazor chat app, dependency
+> injection, ingestion, embeddings, semantic search, and RAG.
+
+## Completed code for this part
+
+The finished version of the app you are about to build lives in
+**[`Part 11 - Deployment/GenAiLab/`](../Part%2011%20-%20Deployment/GenAiLab/)**.
+
+It is the same solution, already scaffolded, already updated to the current
+package versions, and already carrying every change this part asks you to make.
+Part 11 reuses it for deployment, which is why it lives there rather than in this
+folder. The **only** difference from a correctly completed Part 4 is one line that
+Part 11 adds — `WithExternalHttpEndpoints()` in `AppHost.cs` — which is harmless
+when running locally.
+
+Use it to check your work if a step doesn't behave, or to catch up if you fall
+behind. It still needs your own credentials: see [Step 2.4](#24-store-the-connection-string)
+and set `ConnectionStrings:openai` on `GenAiLab.AppHost`.
 
 ## Step 1: Install the template and scaffold
 
@@ -66,66 +85,28 @@ This generates a solution with three projects:
 | `GenAiLab.AppHost` | The **Aspire** orchestrator (starts the app, Qdrant, and a document reader) |
 | `GenAiLab.ServiceDefaults` | Shared telemetry, health checks, resilience |
 
-### Docker-free path: local vector store without Aspire
-
-The template also supports a single-project variant that stores vectors in a local
-SQLite file and skips containers entirely. Scaffold it with:
-
-```bash
-dotnet new aichatweb --provider azureopenai --vector-store local --managed-identity false --name GenAiLab --output GenAiLab
-```
-
-In Visual Studio, choose **Local** for the vector store, leave **Use Aspire
-orchestration** disabled, and clear **Use managed identity**.
-
-`--managed-identity false` matters. Left at its default the template authenticates
-with Entra ID, which requires your signed-in account to hold the **Azure AI
-Developer** role on the Azure OpenAI resource. Turning it off gives you API-key
-authentication and the same two secrets you already used in Parts 2 and 3:
-
-```bash
-dotnet user-secrets --project GenAiLab set AzureOpenAI:Endpoint "https://YOUR-RESOURCE.openai.azure.com/"
-dotnet user-secrets --project GenAiLab set AzureOpenAI:Key "YOUR-KEY"
-dotnet run --project GenAiLab
-```
-
-This variant is not just "the Aspire one minus the containers" — it differs in
-several ways worth knowing about:
-
-| | Aspire path | Docker-free path |
-| --- | --- | --- |
-| Projects | Three (Web, AppHost, ServiceDefaults) | One |
-| Vector store | Qdrant container with a data volume | SQLite file via `AddSqliteVectorStore` |
-| PDF reading | `mcp/markitdown` container | `PdfPig`, in-process |
-| Chat API | `AddChatClient("gpt-5-mini")` | `GetResponsesClient().AsIChatClient("gpt-5-mini")` |
-
-Use the rest of this part to inspect the same chat, embedding, ingestion, and
-retrieval abstractions. The file names and the roles they play are the same; only
-the wiring differs.
-
-| You can still complete | This path omits |
-| --- | --- |
-| Blazor chat UI and AI client configuration | Qdrant and its persistent container volume |
-| Document ingestion, embeddings, and semantic search | The Aspire AppHost and service orchestration |
-| RAG and the vector-store abstraction | The Aspire dashboard, distributed health checks, logs, traces, and metrics |
-
-Skip Steps 3 and 4, and read the AppHost sections as an architecture comparison
-rather than files that exist in your generated project.
+## Step 2: Configure it before you run it
 
 > [!IMPORTANT]
-> `dotnet restore` on this variant reports `NU1903` for a transitive
-> `SQLitePCLRaw.lib.e_sqlite3` 2.1.10 reference. Pin the fixed version to clear it:
->
-> ```bash
-> dotnet add GenAiLab package SQLitePCLRaw.bundle_e_sqlite3 --version 3.0.4
-> ```
+> Do this **before** you press F5 or run `dotnet run`. A freshly scaffolded project
+> is not ready to talk to the workshop's Azure OpenAI resource, and running it
+> first produces a confusing *Azure provisioning* prompt rather than a useful error.
 
-### Bring the packages up to date
+Four things need to change, and all four are small:
+
+| # | Change | File |
+| --- | --- | --- |
+| 2.1 | Bring the packages up to date | both `.csproj` files |
+| 2.2 | Point the AppHost at an **existing** resource | `GenAiLab.AppHost/AppHost.cs` |
+| 2.3 | Use the deployment name your resource actually has | `GenAiLab.Web/Program.cs` |
+| 2.4 | Store the connection string | user secrets on `GenAiLab.AppHost` |
+
+### 2.1 Bring the packages up to date
 
 Templates ship on their own release cadence, so a freshly scaffolded project is
 usually a few versions behind the current packages. Update it before you go any
 further — this is what you would do on any real project, and it keeps your code
-matching the snapshot in this repo.
+matching the completed solution in this repo.
 
 This is not only housekeeping. The template scaffolds Aspire **13.0.0**, which
 pulls in a MessagePack version carrying known high-severity advisories, so
@@ -154,21 +135,244 @@ dotnet add GenAiLab.Web package Microsoft.SemanticKernel.Connectors.Qdrant --pre
 `--prerelease` because neither has ever shipped a stable build; without the flag
 the command fails.
 
-Then confirm everything still restores and compiles:
+> [!NOTE]
+> The completed solution in this repo pins exact versions, so if a newer release
+> has shipped since this was written you may end up slightly ahead of it. That is
+> fine — the code in this part does not depend on anything that changed.
+
+**Already ran the app before doing this step?** Updating Aspire also updates the
+Qdrant container image, and the data volume written by the old version can stop the
+new one from starting. See
+[Qdrant won't start after updating packages](#qdrant-wont-start-after-updating-packages)
+in Step 3.
+
+### 2.2 Point the AppHost at your existing Azure OpenAI resource
+
+The template assumes you want Aspire to **create** an Azure OpenAI account for you.
+That is what `builder.AddAzureOpenAI("openai")` means: it declares a provisionable
+Azure resource, and the two `AddDeployment` calls describe the models to deploy
+into it. Run it as-is and the Aspire dashboard stops with an *Azure provisioning*
+prompt asking for a tenant, subscription, and location.
+
+For the workshop you already have a resource, so point at it instead. In
+`GenAiLab.AppHost/AppHost.cs`, delete this whole block from the top of the file:
+
+```csharp
+// See https://learn.microsoft.com/dotnet/aspire/azure/local-provisioning#configuration
+// for instructions providing configuration values
+var openai = builder.AddAzureOpenAI("openai");
+
+openai.AddDeployment(
+    name: "gpt-4o-mini",
+    modelName: "gpt-4o-mini",
+    modelVersion: "2024-07-18");
+
+openai.AddDeployment(
+    name: "text-embedding-3-small",
+    modelName: "text-embedding-3-small",
+    modelVersion: "1");
+```
+
+and replace it with one line:
+
+```csharp
+var openai = builder.AddConnectionString("openai");
+```
+
+`AddConnectionString` declares no Azure resource at all — Aspire just reads the
+`openai` connection string from configuration and passes it to the web project.
+Leave the rest of `AppHost.cs` alone; `WithReference(openai)` further down keeps
+working unchanged.
+
+Then drop the package that the provisioning code needed:
+
+```bash
+dotnet remove GenAiLab.AppHost package Aspire.Hosting.Azure.CognitiveServices
+```
+
+> [!IMPORTANT]
+> Setting `ConnectionStrings:openai` does **not** make `AddAzureOpenAI` skip
+> provisioning — it is ignored, and the dashboard still asks for a subscription.
+> The dialog behind the dashboard's **Enter values** button collects tenant,
+> subscription, resource group, and location, so there is nowhere to paste an
+> endpoint and key. Swapping to `AddConnectionString` is the fix.
+>
+> If you *do* want Aspire to provision the resource — in [Part 11](../Part%2011%20-%20Deployment/README.md), against your own subscription — put the template's
+> version back. You will need Owner or User Access Administrator on the
+> subscription, because provisioning also creates role assignments.
+
+### 2.3 Use the deployment name your resource actually has
+
+The template hardcodes `gpt-4o-mini`; the workshop resource deploys `gpt-5-mini`.
+In `GenAiLab.Web/Program.cs`, change:
+
+```csharp
+openai.AddChatClient("gpt-4o-mini")
+```
+
+to:
+
+```csharp
+openai.AddChatClient("gpt-5-mini")
+```
+
+That string is a **deployment** name, not a model name — it has to match what is
+deployed on the resource you are pointing at. If yours is named something else,
+use that instead. This is the same coupling you will work around in
+[Part 10](../Part%2010%20-%20Choosing%20Providers%20and%20Services/README.md).
+
+The embedding line below it already matches, so leave
+`openai.AddEmbeddingGenerator("text-embedding-3-small")` as it is.
+
+### 2.4 Store the connection string
+
+The AppHost needs one setting, `ConnectionStrings:openai`, and it goes in **user
+secrets** — the same secrets-first rule as Parts 2 and 3. Never put a key in
+`appsettings.json`.
+
+> [!IMPORTANT]
+> The secret belongs to **`GenAiLab.AppHost`**, not `GenAiLab.Web`. Aspire reads it
+> in the AppHost and injects it into the web project at launch, so setting it on
+> the wrong project silently does nothing.
+
+The value is a single string combining the endpoint and key from
+[Part 1](../Part%2001%20-%20Setup/README.md):
+
+```text
+Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY
+```
+
+#### Visual Studio
+
+1. In **Solution Explorer**, right-click the **`GenAiLab.AppHost`** project.
+1. Choose **Manage User Secrets**. Visual Studio creates and opens `secrets.json`.
+1. Replace the contents with this, substituting your own endpoint and key:
+
+    ```json
+    {
+      "ConnectionStrings": {
+        "openai": "Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY"
+      }
+    }
+    ```
+
+1. Save the file. It lives outside your project folder, so it is never committed.
+
+> [!TIP]
+> `secrets.json` must be valid JSON. If the app still reports a missing connection
+> string, the usual causes are a trailing comma, a missing closing brace, or having
+> opened **Manage User Secrets** on `GenAiLab.Web` by mistake.
+
+#### Command line
+
+From the `GenAiLab` folder:
+
+```bash
+dotnet user-secrets --project GenAiLab.AppHost set ConnectionStrings:openai "Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY"
+```
+
+Confirm it landed where you expect:
+
+```bash
+dotnet user-secrets --project GenAiLab.AppHost list
+```
+
+You should see exactly one entry, `ConnectionStrings:openai`.
+
+### 2.5 Check it compiles
+
+From the `GenAiLab` folder:
 
 ```bash
 dotnet build
 ```
 
-> [!NOTE]
-> The snapshot in this repo pins exact versions, so if a newer release has
-> shipped since this was written you may end up slightly ahead of it. That is
-> fine — the code in this part does not depend on anything that changed.
+Expect a clean build with no warnings. `NU1903` here means step 2.1 was missed;
+an error about `AddAzureOpenAI` or `AddDeployment` means step 2.2 is incomplete.
 
-## Step 2: Map the generated code to what you built by hand
+## Step 3: Run the app
 
-Everything below is code the template wrote, and it maps directly to the parts
-you already built.
+> [!IMPORTANT]
+> For Aspire solutions, launch the `GenAiLab.AppHost` project. AppHost bootstraps the other projects and supporting services (such as Qdrant). If you run only `GenAiLab.Web`, you skip the full orchestrated experience.
+
+Make sure Docker Desktop is running, then:
+
+```bash
+cd GenAiLab
+dotnet run --project GenAiLab.AppHost
+```
+
+In Visual Studio, set **`GenAiLab.AppHost`** as the startup project and press
+Ctrl+F5.
+
+Aspire launches a **dashboard** (URL printed in the console) showing every service,
+its health, logs, traces, and metrics. This is why `UseOpenTelemetry(...)` was in
+`Program.cs`: the telemetry you registered now has a destination.
+
+> [!TIP]
+> If the dashboard shows an **Azure provisioning** prompt asking for a subscription,
+> step 2.2 didn't take effect — `AppHost.cs` is still calling `AddAzureOpenAI`.
+
+### Qdrant won't start after updating packages
+
+If you ran the app before Step 2.1 and then updated the packages, `vectordb` may
+never reach **Running**. Its logs in the Aspire dashboard show a storage or version
+error rather than the usual startup banner.
+
+Two things in `AppHost.cs` cause this, and both are deliberate:
+
+```csharp
+var vectorDB = builder.AddQdrant("vectordb")
+    .WithDataVolume()                                  // storage survives shutdown
+    .WithLifetime(ContainerLifetime.Persistent);       // container survives shutdown
+```
+
+`WithDataVolume()` is the whole point of this part — it is the answer to Part 3's
+vectors vanishing on exit. But bumping Aspire also bumps the Qdrant image, and a
+data volume written by the older Qdrant can be incompatible with the newer one.
+`WithLifetime(ContainerLifetime.Persistent)` compounds it: the old container is
+kept and reused rather than recreated, so it does not pick up the new image.
+
+The fix is to throw away both. Nothing of value is lost — the volume holds only
+embeddings of the two sample documents, which the app regenerates on your next
+question.
+
+```bash
+# find the leftovers (Aspire names them after your AppHost)
+docker ps -a --filter "name=vectordb"
+docker volume ls --filter "name=vectordb-data"
+
+# remove them, substituting the names you just saw
+docker rm -f vectordb-38984c72
+docker volume rm genailab.apphost-38984c7271-vectordb-data
+```
+
+In Docker Desktop, do the same from the **Containers** and **Volumes** tabs.
+
+Then run the AppHost again. Aspire recreates the container from the new image with
+an empty volume, and your first question re-ingests the sample documents — so it
+will be slow again, exactly like the first run.
+
+> [!TIP]
+> Doing Step 2 in order avoids this entirely: update the packages *before* the
+> first run and there is never an old volume to conflict with.
+
+## Step 4: Test the app end to end
+
+1. In the Aspire dashboard, wait until `aichatweb-app`, `vectordb`, and `markitdown` are running.
+1. Open the `aichatweb-app` URL from the dashboard.
+1. Ask a question grounded in the sample data, for example "What water purification supplies are in the emergency survival kit?"
+1. The first question takes a while — that is ingestion running for the first time, including sending the sample PDF to the markitdown container. Later questions are fast.
+1. Confirm the answer carries citations back to `Example_Emergency_Survival_Kit.pdf` or `Example_GPS_Watch.md` rather than reading like a generic model response. Clicking a citation opens the source document at the quoted text.
+1. In the dashboard, open logs and traces for `aichatweb-app` to see the search calls the model made on its own — the template registers search as a tool, so the model decides when to retrieve.
+
+If you want the official step-by-step quickstart for scaffold + config + first run, see:
+[.NET AI templates quickstart](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/ai-templates?tabs=visual-studio%2Cconfigure-visual-studio&pivots=azure-openai).
+
+## Step 5: Map the generated code to what you built by hand
+
+Now that it runs, read what the template wrote. All of it maps directly to the
+parts you already built.
 
 ### Chat client: your Part 2 pipeline, as DI configuration
 
@@ -176,15 +380,12 @@ you already built.
 
 ```csharp
 var openai = builder.AddAzureOpenAIClient("openai");
-openai.AddChatClient("gpt-4o-mini")
+openai.AddChatClient("gpt-5-mini")
     .UseFunctionInvocation()
     .UseOpenTelemetry(configure: c =>
         c.EnableSensitiveData = builder.Environment.IsDevelopment());
 openai.AddEmbeddingGenerator("text-embedding-3-small");
 ```
-
-The template hardcodes `gpt-4o-mini`. You will change that to `gpt-5-mini` in
-Step 3, because that is the deployment name on the workshop resource.
 
 | Part 2/3 (by hand) | Template (generated) |
 | --- | --- |
@@ -194,6 +395,11 @@ Step 3, because that is the deployment name on the workshop resource.
 
 Same abstractions, now registered in DI and wrapped with a richer middleware
 pipeline (function calling + telemetry instead of your hand-added logging).
+
+Note what the endpoint and key did *not* do here: there is no `new
+AzureOpenAIClient(endpoint, key)`. `AddAzureOpenAIClient("openai")` looks up a
+connection string **by name**, and Aspire supplied it from the AppHost. That
+indirection is the reason step 2.4 set the secret on the AppHost instead.
 
 ### Retrieval: your Part 3 cosine search, as a service
 
@@ -266,13 +472,10 @@ search, which is why your first question takes noticeably longer than the rest.
 
 ### Persistence + orchestration: the answer to "in-memory doesn't scale"
 
-`GenAiLab.AppHost/AppHost.cs`:
+`GenAiLab.AppHost/AppHost.cs`, as you left it after step 2.2:
 
 ```csharp
-var openai = builder.AddAzureOpenAI("openai");
-
-openai.AddDeployment(name: "gpt-4o-mini", modelName: "gpt-4o-mini", modelVersion: "2024-07-18");
-openai.AddDeployment(name: "text-embedding-3-small", modelName: "text-embedding-3-small", modelVersion: "1");
+var openai = builder.AddConnectionString("openai");
 
 var vectorDB = builder.AddQdrant("vectordb")
     .WithDataVolume()
@@ -293,86 +496,110 @@ container with a persistent data volume**, and Aspire starts the database and th
 document reader, waits for them to be ready, then starts the web app and wires the
 connection strings and endpoints between them automatically.
 
-## Step 3: Point the app at the workshop's Azure OpenAI resource
+## Alternative: Docker-free path (local vector store without Aspire)
 
-The template assumes you want Aspire to **create** an Azure OpenAI account for you.
-That is what `builder.AddAzureOpenAI("openai")` means: it declares a provisionable
-Azure resource, and the two `AddDeployment` calls describe the models to deploy
-into it. Run it as-is and the Aspire dashboard stops with an *Azure provisioning*
-prompt asking for a tenant, subscription, and location.
+The template also supports a single-project variant that stores vectors in a local
+SQLite file and skips containers entirely. Use this if you cannot run Docker.
 
-For the workshop you already have a resource, so point at it instead. Replace the
-whole `AddAzureOpenAI` block at the top of `AppHost.cs` with one line:
+Everything in Steps 1-4 applies, but the configuration is different enough that
+the whole path is given here. Read Step 5 as an architecture comparison rather
+than a description of files in your project.
+
+### Scaffold it
+
+```bash
+dotnet new aichatweb --provider azureopenai --vector-store local --managed-identity false --name GenAiLab --output GenAiLab
+```
+
+In Visual Studio, choose **Local** for the vector store, leave **Use Aspire
+orchestration** disabled, and clear **Use managed identity**.
+
+`--managed-identity false` matters. Left at its default the template authenticates
+with Entra ID, which requires your signed-in account to hold the **Azure AI
+Developer** role on the Azure OpenAI resource. Turning it off gives you API-key
+authentication and the same two secrets you already used in Parts 2 and 3.
+
+### Configure it before you run it
+
+There is no AppHost here, so all three changes are in the single `GenAiLab`
+project.
+
+**Set the deployment name.** Exactly as in [step 2.3](#23-use-the-deployment-name-your-resource-actually-has),
+this variant also hardcodes `gpt-4o-mini`, just through a different API. In
+`GenAiLab/Program.cs`, change:
 
 ```csharp
-var openai = builder.AddConnectionString("openai");
+var chatClient = azureOpenAi.GetResponsesClient().AsIChatClient("gpt-4o-mini");
 ```
 
-`AddConnectionString` declares no Azure resource at all — Aspire just reads the
-`openai` connection string from configuration and passes it to the web project.
-Then drop the package that the provisioning code needed:
-
-```bash
-dotnet remove GenAiLab.AppHost package Aspire.Hosting.Azure.CognitiveServices
-```
-
-> [!IMPORTANT]
-> Setting `ConnectionStrings:openai` does **not** make `AddAzureOpenAI` skip
-> provisioning — it is ignored, and the dashboard still asks for a subscription.
-> The dialog behind the dashboard's **Enter values** button collects tenant,
-> subscription, resource group, and location, so there is nowhere to paste an
-> endpoint and key. Swapping to `AddConnectionString` is the fix.
->
-> If you *do* want Aspire to provision the resource — in [Part 11](../Part%2011%20-%20Deployment/README.md), against your own subscription — put the template's
-> version back. You will need Owner or User Access Administrator on the
-> subscription, because provisioning also creates role assignments.
-
-While you are in there, change the model name. The template hardcodes
-`gpt-4o-mini`; the workshop resource deploys `gpt-5-mini`. In
-`GenAiLab.Web/Program.cs`:
+to:
 
 ```csharp
-openai.AddChatClient("gpt-5-mini")
+var chatClient = azureOpenAi.GetResponsesClient().AsIChatClient("gpt-5-mini");
 ```
 
-That string is a **deployment** name, not a model name — it has to match what is
-deployed on the resource you are pointing at. This is the same coupling you will
-work around in [Part 10](../Part%2010%20-%20Choosing%20Providers%20and%20Services/README.md).
+Skipping this is the most common failure on this path: the app builds and starts
+fine, then the first chat message fails with a 404 because `gpt-4o-mini` is not
+deployed on the workshop resource.
 
-Finally, store the credentials. The AppHost reads them from user secrets, same
-secrets-first rule as Parts 2-3:
+**Store the credentials.** This variant reads two plain settings rather than a
+connection string, because there is no Aspire to compose one:
 
 ```bash
-dotnet user-secrets --project GenAiLab.AppHost set ConnectionStrings:openai "Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY"
+dotnet user-secrets --project GenAiLab set AzureOpenAI:Endpoint "https://YOUR-RESOURCE.openai.azure.com/"
+dotnet user-secrets --project GenAiLab set AzureOpenAI:Key "YOUR-KEY"
 ```
 
-## Step 4: Run the app
+In Visual Studio, right-click the **`GenAiLab`** project → **Manage User Secrets**
+and paste:
 
-Run the AppHost:
+```json
+{
+  "AzureOpenAI": {
+    "Endpoint": "https://YOUR-RESOURCE.openai.azure.com/",
+    "Key": "YOUR-KEY"
+  }
+}
+```
 
-> [!IMPORTANT]
-> For Aspire solutions, launch the `GenAiLab.AppHost` project. AppHost bootstraps the other projects and supporting services (such as Qdrant). If you run only `GenAiLab.Web`, you skip the full orchestrated experience.
+**Clear the package advisory.** `dotnet restore` reports `NU1903` for a transitive
+`SQLitePCLRaw.lib.e_sqlite3` 2.1.10 reference. Pin the fixed version:
 
 ```bash
-cd GenAiLab
-dotnet run --project GenAiLab.AppHost
+dotnet add GenAiLab package SQLitePCLRaw.bundle_e_sqlite3 --version 3.0.4
 ```
 
-Aspire launches a **dashboard** (URL printed in the console) showing every service,
-its health, logs, traces, and metrics. This is why `UseOpenTelemetry(...)` was in
-`Program.cs`: the telemetry you registered now has a destination.
+### Run it
 
-## Step 5: Test the app end to end
+```bash
+dotnet run --project GenAiLab
+```
 
-1. In the Aspire dashboard, wait until `aichatweb-app`, `vectordb`, and `markitdown` are running.
-1. Open the `aichatweb-app` URL from the dashboard.
-1. Ask a question grounded in the sample data, for example "What water purification supplies are in the emergency survival kit?"
-1. The first question takes a while — that is ingestion running for the first time, including sending the sample PDF to the markitdown container. Later questions are fast.
-1. Confirm the answer carries citations back to `Example_Emergency_Survival_Kit.pdf` or `Example_GPS_Watch.md` rather than reading like a generic model response. Clicking a citation opens the source document at the quoted text.
-1. In the dashboard, open logs and traces for `aichatweb-app` to see the search calls the model made on its own — the template registers search as a tool, so the model decides when to retrieve.
+Then open the printed URL and test with the same questions as Step 4. There is no
+Aspire dashboard on this path, so logs go to the console.
 
-If you want the official step-by-step quickstart for scaffold + config + first run, see:
-[.NET AI templates quickstart](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/ai-templates?tabs=visual-studio%2Cconfigure-visual-studio&pivots=azure-openai).
+### How the two paths differ
+
+This variant is not just "the Aspire one minus the containers":
+
+| | Aspire path | Docker-free path |
+| --- | --- | --- |
+| Projects | Three (Web, AppHost, ServiceDefaults) | One |
+| Vector store | Qdrant container with a data volume | SQLite file via `AddSqliteVectorStore` |
+| PDF reading | `mcp/markitdown` container | `PdfPig`, in-process |
+| Chat API | `AddChatClient("gpt-5-mini")` | `GetResponsesClient().AsIChatClient("gpt-5-mini")` |
+| Credentials | `ConnectionStrings:openai` on the AppHost | `AzureOpenAI:Endpoint` + `AzureOpenAI:Key` on the app |
+
+| You can still complete | This path omits |
+| --- | --- |
+| Blazor chat UI and AI client configuration | Qdrant and its persistent container volume |
+| Document ingestion, embeddings, and semantic search | The Aspire AppHost and service orchestration |
+| RAG and the vector-store abstraction | The Aspire dashboard, distributed health checks, logs, traces, and metrics |
+
+> [!NOTE]
+> [Part 11](../Part%2011%20-%20Deployment/README.md) deploys the Aspire path. If you
+> took this one, read Part 11 as a walkthrough rather than following along, or use
+> the completed solution in `Part 11 - Deployment/GenAiLab/`.
 
 ## What you learned
 

--- a/Part 11 - Deployment/GenAiLab/README.md
+++ b/Part 11 - Deployment/GenAiLab/README.md
@@ -1,5 +1,26 @@
 # AI Chat with Custom Data
 
+> [!IMPORTANT]
+> **Workshop note.** This file is the template's own generated README. This copy of
+> the app is the completed code for both
+> [Part 4](../../Part%2004%20-%20AI%20Web%20Chat%20Template/README.md) and
+> [Part 11](../README.md), and it has already been modified for the workshop:
+> `AppHost.cs` uses `builder.AddConnectionString("openai")` to point at an
+> **existing** Azure OpenAI resource instead of provisioning a new one, and the chat
+> deployment is `gpt-5-mini`. So ignore the "Using Azure Provisioning" section below
+> — instead, set `ConnectionStrings:openai` in user secrets on `GenAiLab.AppHost`:
+>
+> ```json
+> {
+>   "ConnectionStrings": {
+>     "openai": "Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY"
+>   }
+> }
+> ```
+>
+> In Visual Studio, right-click `GenAiLab.AppHost` → **Manage User Secrets**. Run the
+> solution by launching the `GenAiLab.AppHost` project.
+
 This project is an AI chat application that demonstrates how to chat with custom data using an AI language model. Please note that this template is currently in an early preview stage. If you have feedback, please take a [brief survey](https://aka.ms/dotnet-chat-templatePreview2-survey).
 
 >[!NOTE]

--- a/Part 11 - Deployment/README.md
+++ b/Part 11 - Deployment/README.md
@@ -11,6 +11,34 @@ In this final part, you will learn how to deploy the AI Web Chat application you
 > [!TIP]
 > If you haven't completed the previous steps in the lab or are having trouble with your code, you can use the working code snapshot provided in this `Part 11 - Deployment` folder. The complete code has already been updated with the necessary configuration for external HTTP endpoints and deployment. You can skip directly to the "Set Up the Azure Developer CLI" section and deploy that code instead.
 
+## `GenAiLab/` is also the completed code for Part 4
+
+There is deliberately only one copy of this solution in the repository, and it lives
+here because Part 11 is the part that deploys it.
+[`GenAiLab/`](GenAiLab/) is a correctly finished
+[Part 4](../Part%2004%20-%20AI%20Web%20Chat%20Template/README.md) — current package
+versions, `AddConnectionString("openai")` in `AppHost.cs`, and `gpt-5-mini` as the
+chat deployment — plus the single `WithExternalHttpEndpoints()` line added in the
+next section, which is harmless when running locally.
+
+So if you started from this snapshot rather than from your own Part 4 output, that
+line is already there and you can skip the next section.
+
+Either way, you supply your own credentials. Set `ConnectionStrings:openai` in user
+secrets on **`GenAiLab.AppHost`** — in Visual Studio, right-click the project and
+choose **Manage User Secrets**:
+
+```json
+{
+  "ConnectionStrings": {
+    "openai": "Endpoint=https://YOUR-RESOURCE.openai.azure.com/;Key=YOUR-KEY"
+  }
+}
+```
+
+Or let `.github/scripts/setup-workshop-credentials.ps1 -ApplyUserSecrets` write it
+for you.
+
 ## Configure the web application for external access
 
   Before the web application is deployed to Azure Container Apps, you will need to configure it so that it is available via web browser. Update `GenAiLab.AppHost/AppHost.cs` to add the following line just before the call to `builder.Build().Run();` at the end of the file:
@@ -21,6 +49,11 @@ In this final part, you will learn how to deploy the AI Web Chat application you
 
 > [!IMPORTANT]
 > This is an Aspire solution. Always launch the `GenAiLab.AppHost` project when running locally because AppHost bootstraps the full distributed app (web app + supporting services).
+
+If `vectordb` never reaches **Running** when you run this locally, you are probably
+hitting a Qdrant data volume left behind by an older package version. See
+[Qdrant won't start after updating packages](../Part%2004%20-%20AI%20Web%20Chat%20Template/README.md#qdrant-wont-start-after-updating-packages)
+in Part 4 — remove the stale container and volume, then run again.
 
 ## Set Up the Azure Developer CLI
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Docker Desktop or Podman is required when you run the workshop's **Qdrant contai
 | Parts | Docker requirement |
 | --- | --- |
 | Parts 1-3 | Not required. These use console applications and an in-memory vector store. |
-| Part 4 | Required for the recommended Qdrant + Aspire path. A supported Docker-free path uses the template's local JSON vector store without Aspire; see the [Part 4 instructions](Part%2004%20-%20AI%20Web%20Chat%20Template/README.md#docker-free-path-local-vector-store-without-aspire). |
+| Part 4 | Required for the recommended Qdrant + Aspire path. A supported Docker-free path uses the template's local SQLite vector store without Aspire; see the [Part 4 instructions](Part%2004%20-%20AI%20Web%20Chat%20Template/README.md#alternative-docker-free-path-local-vector-store-without-aspire). |
 | Part 5 | Not required for the MCP exercises. |
 | Parts 6-7 | Not required. Containerizing an MCP server in Part 7 is optional. |
 | Part 8 | Not required. This module includes a standalone `AgentApp` sample and remains Docker-free. |
@@ -124,6 +124,11 @@ The repository is structured as follows:
 - 📖 `Part 01 - Setup` through `Part 11 - Deployment`: Contains all the lab instructions, documentation, and working code snapshots
 - 📄 `manuals/`: Product documentation PDFs for the AI chatbot exercises
 - 🧪 `docs/`: Instructor guides, testing procedures, and archived reports
+
+Most parts keep their completed code beside their own README. The one exception is
+**Part 4**, whose finished solution lives in `Part 11 - Deployment/GenAiLab/` because
+Part 11 deploys that same app. It is a correctly completed Part 4 plus the single
+`WithExternalHttpEndpoints()` line that Part 11 adds.
 
 ## Session Resources 📚
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ This directory contains all documentation related to the .NET AI Workshop develo
 
 New test reports are written here using the template and skill at [`.github/skills/workshop-testing/`](../.github/skills/workshop-testing/SKILL.md). Name files `workshop-test-report-<YYYY-MM-DD>.md`.
 
+- **[workshop-test-report-2026-07-27.md](testing/workshop-test-report-2026-07-27.md)** - Full run of Parts 1-11 against live Microsoft Foundry (deployment excluded)
+
 ### 🗄️ Archived Historical Artifacts (`/archive`)
 
 - **[MCP_WORKSHOP_PLANNING.md](archive/planning/MCP_WORKSHOP_PLANNING.md)** - Legacy implementation plan retained for historical context

--- a/docs/testing/workshop-test-report-2026-07-27.md
+++ b/docs/testing/workshop-test-report-2026-07-27.md
@@ -16,7 +16,7 @@ retest; both are recorded below.
 
 - .NET SDK: `10.0.400-preview.0.26322.102` (default; 10.0.110, 9.0.316 and 9.0.200 also
   installed, no `global.json`)
-- OS: Windows, PowerShell, `core.autocrlf=true`, no `.gitattributes` in the repo
+- OS: Windows, PowerShell, `core.autocrlf=true`
 - Docker: 29.6.2, running
 - Template versions: `Microsoft.Extensions.AI.Templates` 10.7.0-preview.3.26309.5,
   `Aspire.ProjectTemplates` 9.4.2 (repo pins Aspire 13.4.6)

--- a/docs/testing/workshop-test-report-2026-07-27.md
+++ b/docs/testing/workshop-test-report-2026-07-27.md
@@ -1,0 +1,463 @@
+# Workshop Test Report - 2026-07-27
+
+A full attendee-style run of all 11 parts. Every project was scaffolded from `dotnet new`
+in a scratch `test-workspace/` rather than copied from a snapshot, and every code part was
+run against live Microsoft Foundry (Azure OpenAI). The Azure deployment in Part 11 was out
+of scope by agreement; Part 11 was tested configuration-only.
+
+Repo at `aad12bd`, which includes #566 ("Align Parts 4 and 11 with the current aichatweb
+template"). Part 4 was tested twice — once before that PR merged and once after — and the
+post-merge result is what this report records.
+
+Part 3 was retested at `14974aa` after #579 landed. It failed the original run and passes the
+retest; both are recorded below.
+
+## Environment
+
+- .NET SDK: `10.0.400-preview.0.26322.102` (default; 10.0.110, 9.0.316 and 9.0.200 also
+  installed, no `global.json`)
+- OS: Windows, PowerShell, `core.autocrlf=true`, no `.gitattributes` in the repo
+- Docker: 29.6.2, running
+- Template versions: `Microsoft.Extensions.AI.Templates` 10.7.0-preview.3.26309.5,
+  `Aspire.ProjectTemplates` 9.4.2 (repo pins Aspire 13.4.6)
+- Foundry Local CLI: 0.10.2, serving `Phi-4-mini-instruct-generic-gpu`
+- Scope tested: full 1-11, excluding `azd up`
+
+## Results
+
+| Part | Status | Time | Notes |
+| --- | --- | --- | --- |
+| 1 - Setup | Pass | ~10 min | Prerequisites and install steps verified |
+| 2 - Build Chat App | Pass | ~35 min | Snapshot matches exactly |
+| 3 - Add RAG | Pass | ~70 min | Failed at `aad12bd`; fixed by #579 and re-verified at `14974aa` |
+| 4 - AI Web Chat Template | Pass | ~50 min | Aspire path fixed by #566; README restructured so configuration comes first, closing #580. Both paths re-verified end to end including RAG |
+| 5 - MCP Server Basics | Pass | ~30 min | All three tools verified over stdio; template drift only |
+| 6 - Enhanced MCP Server | Pass | ~20 min | All three tools verified; four dead links |
+| 7 - MCP Publishing | Pass | ~30 min | Failed at `aad12bd`; fixed by #583 and re-verified at `b7d43cf` |
+| 8 - Agent Framework Basics | Pass | ~25 min | Byte-identical snapshot match — the cleanest part in the workshop |
+| 9 - Adding AI to an Existing App | Pass with issues | ~60 min | All three features verified live; the missing "before" app was added by #584 and re-verified |
+| 10 - Choosing Providers and Services | Pass with issues | ~25 min | Snippets do not compile as printed |
+| 11 - Deployment | Pass | ~20 min | Config-only. Release build clean; reconciliation against Part 4 near-perfect |
+
+Status: Pass / Pass with issues / Fail / Skipped.
+
+## Part detail
+
+### Part 2 - Build Chat App
+
+- **What was run:** `dotnet new console -n ChatApp`, the five packages from the README,
+  `Program.cs` per the README, then `dotnet run` with scripted input.
+- **Result:** Clean build. Streaming, multi-turn history, and the structured `summary`
+  output all worked against `gpt-5-mini`.
+- **Documentation clarity:** No gaps. Package versions resolved exactly as the snapshot pins them.
+- **Snapshot comparison:** Differences are teaching comments and `UserSecretsId` only.
+- **Snapshot updated:** No — nothing to change.
+
+### Part 3 - Add RAG
+
+Was the worst part in the workshop and the only one that failed outright for every attendee.
+**Fixed by #579 and re-verified — now passes.** The original findings are kept below because
+they explain what the fix is defending against.
+
+- **What was run:** Copied the Part 2 app per Step 1, followed Step 2 (manual cosine
+  similarity), then Step 3 (`Microsoft.Extensions.DataIngestion` + `SqliteVec`).
+- **Result (original run, at `aad12bd`):**
+  - **Step 2 ran and answered correctly, but the lesson did not happen.** The console
+    printed `Embedding 1 chunks` instead of `Embedding 11 chunks`. Because the repo had no
+    `.gitattributes` and Git for Windows defaults to `core.autocrlf=true`, the sample
+    document was on disk with CRLF (33 CRLF, 0 bare LF; the git blob is LF), so
+    `Split("\n\n")` never matched. Chunking, top-k selection and cosine ranking — the
+    entire point of Step 2 — silently did not run. The answer was still correct because the
+    whole 1.2 KB document fits in one chunk and is always passed as context, which is
+    exactly why nobody noticed.
+  - **Step 3 crashed.** `MarkdownReader` threw
+    `NotSupportedException: Inline type 'AutolinkInline' is not supported` on
+    `<support@contoso.example>` in the sample document; ingestion reported
+    `Succeeded: False`; then `writer.VectorStoreCollection` threw a second, unhandled
+    `InvalidOperationException` because there was no guard for failed ingestion.
+  - Step 3 also emits **4 `NU1903` high-severity vulnerability warnings** that CI never sees.
+    Still true after #579; tracked as #575.
+- **Retest at `14974aa` (after #579):** Re-ran the whole part as an attendee.
+  - Step 2 prints `Embedding 11 chunks`. Both defenses were checked independently rather
+    than trusting one: the `.gitattributes` rule delivers the file as LF (33 LF, 0 CRLF),
+    **and** force-rewriting the file to genuine CRLF still yields 11 chunks, so the
+    `ReplaceLineEndings("\n")` guard covers a file copied in from outside the repo.
+  - Step 3 reports `Succeeded: 'True'` with no exception, and all three exchanges from the
+    README's Step 4 sample output reproduce, including the out-of-context refusal.
+  - The new failure guard was tested by deliberately re-introducing the autolink. It
+    degrades exactly as documented — prints
+    `Inline type 'AutolinkInline' is not supported.` followed by the stop message, and exits
+    with **code 0** rather than an unhandled exception.
+- **Documentation clarity:** The "What's next" section still claims the knowledge base is
+  in-memory, which contradicts Step 3's SQLite persistence.
+- **Snapshot comparison:** My typed Step 3 `Program.cs` is semantically identical to
+  `checkpoints/medi-program.cs` — 110 significant lines each, zero differences after
+  normalizing indentation and stripping comments. The checkpoint indents with 4 spaces where
+  the README prints 2, which is cosmetic and pre-existing. `ReplaceLineEndings` is present in
+  both `RagChatApp/Program.cs` and `checkpoints/manual-program.cs`. Neither checkpoint is
+  compiled by CI; compiling them by hand — a throwaway console project per variant with
+  exactly the packages each one documents — both build successfully, with
+  `manual-program.cs` clean and `medi-program.cs` raising two of the `NU1903` warnings above.
+  `RagChatApp.csproj` also drops `Microsoft.Extensions.Logging.Console`, which an attendee
+  carries in from Part 2.
+- **Snapshot state:** `RagChatApp` builds Release with 0 warnings and runs correctly
+  (11 chunks, grounded answer). #567, #568 and #569 are closed; #575 remains open.
+
+### Part 4 - AI Web Chat Template
+
+- **What was run:** `dotnet new aichatweb --provider azureopenai --vector-store qdrant --aspire --name GenAiLab --output GenAiLab`,
+  then the rewritten README end to end: package bumps, the AppHost swap to
+  `AddConnectionString`, the `gpt-4o-mini` → `gpt-5-mini` edit, removing
+  `Aspire.Hosting.Azure.CognitiveServices`, and setting the `openai` secret.
+- **Result:** Build 0 warnings. `dotnet run --project GenAiLab.AppHost` reaches
+  "Distributed application started". Driving the real Blazor UI in a browser, the question
+  *"What water purification supplies are in the emergency survival kit?"* returned a
+  grounded answer citing `Example_Emergency_Survival_Kit.pdf` twice, with follow-up
+  suggestions. Qdrant collection `data-genailab-chunks` held **19 points at dim 1536**.
+- **Documentation clarity:** Good on the Aspire path. #566 fixed everything found in the
+  pre-merge pass — the hardcoded `gpt-4o-mini`, the `AddAzureOpenAI` vs `AddConnectionString`
+  mismatch that caused a startup crash, and the missing
+  `Aspire.Hosting.Azure.CognitiveServices` handling.
+- **Docker-free `--vector-store local` path:** Scaffolded and run separately with the exact
+  README command including `--managed-identity false`. The README's `NU1903` note is accurate
+  and its fix works — `dotnet restore` does flag transitive `SQLitePCLRaw.lib.e_sqlite3`
+  2.1.10, and pinning `SQLitePCLRaw.bundle_e_sqlite3` 3.0.4 clears it to 0 warnings. Ingestion
+  into SQLite and a grounded, cited answer both verified in a browser. **But the template
+  hardcodes `gpt-4o-mini` on this path too**, and the fix for that lives in Step 3, which
+  line 112 tells Docker-free readers to skip — while the comparison table at line 100 claims
+  this path already uses `gpt-5-mini`. The instructor proxy has a genuine `gpt-4o-mini`
+  deployment (confirmed: it answers as `gpt-4o-mini-2024-07-18`, and an invented model name
+  404s), so the defect is invisible in rehearsal but 404s on the attendee's own Part 1
+  resource, which deploys only `gpt-5-mini` and `text-embedding-3-small`. Filed #580.
+- **README restructure (post-run):** Attendee feedback during rehearsal was that the
+  configuration steps were unclear and came too late. The part was reorganized so that all
+  four configuration changes — package updates, the `AddConnectionString` swap, the
+  deployment-name change, and the connection-string secret — now live in a single **Step 2
+  "Configure it before you run it"**, immediately after scaffolding and ahead of the code
+  walkthrough (which moved to Step 5, after the app runs). The secret is now documented for
+  **both** Visual Studio's *Manage User Secrets* (with the exact `secrets.json` shape) and
+  the CLI, and it states explicitly that the secret belongs to `GenAiLab.AppHost` rather than
+  `GenAiLab.Web`. The Docker-free path moved out of Step 1 into its own end-of-part section
+  carrying a **complete** configuration of its own, which closes #580: it now shows the
+  `AsIChatClient("gpt-4o-mini")` → `"gpt-5-mini"` edit in place, and the comparison table
+  gained a credentials row so the two credential models are not confused.
+- **Post-restructure verification:** Both paths were re-run against the live resource.
+  - Aspire path: the committed solution builds Release 0 warnings, starts with **no Azure
+    provisioning prompt**, brings up `vectordb` and `markitdown`, and answers the water
+    purification question with two working citations into
+    `Example_Emergency_Survival_Kit.pdf`.
+  - Docker-free path: re-scaffolded, applied the newly documented edits (`gpt-5-mini`,
+    the two `AzureOpenAI:*` secrets, the `SQLitePCLRaw.bundle_e_sqlite3` 3.0.4 pin), built
+    **0 warnings**, and got the same grounded answer with the same two citations via PdfPig
+    and SQLite.
+  - One incidental finding: `GenAiLab.AppHost` had **no** user secret set, because #566
+    re-scaffolded the project and changed its `UserSecretsId`. Re-running
+    `setup-workshop-credentials.ps1 -ApplyUserSecrets` fixes it; worth knowing whenever that
+    project is regenerated.
+- **Completed code:** Part 4 has no snapshot of its own by design. `Part 11 -
+  Deployment/GenAiLab/` is the finished Part 4 plus one line, and that is now stated in the
+  Part 4 README, the Part 11 README, the snapshot's own README, and the root README.
+- **Stale Qdrant volume (found in rehearsal, now documented):** Running the app *before*
+  step 2.1 and then updating the packages can leave `vectordb` unable to start. Bumping
+  Aspire also bumps the Qdrant image, and `WithDataVolume()` keeps storage written by the
+  older version, while `WithLifetime(ContainerLifetime.Persistent)` keeps the old container
+  instead of recreating it from the new image. Step 3 gained a **"Qdrant won't start after
+  updating packages"** section explaining both causes and giving the cleanup, and Part 11
+  links to it because it runs the same solution.
+  - Verified by doing it: `docker rm -f <container>` then `docker volume rm <volume>` both
+    succeed (order matters — Docker refuses to remove a volume still attached to a
+    container, which is why the documented commands are in that order). Re-running the
+    AppHost recreated the container and an empty volume, re-ingested the sample documents on
+    the first question, and returned the same cited answer.
+- **Snapshot comparison:** See the reconciliation table — near-perfect.
+- **Snapshot updated:** No — already correct.
+
+### Part 5 - MCP Server Basics
+
+- **What was run:** `dotnet new mcpserver -n MyMcpServer`, added `WeatherTools.cs` and
+  updated `Program.cs` per the README, then drove the built executable over stdio with a
+  raw `ProcessStartInfo` harness.
+- **Result:** Clean build. `initialize` + `tools/list` returns `get_random_number`,
+  `get_weather_forecast` and `get_current_weather`; `tools/call` verified for two of them.
+- **Documentation clarity:** Four small drifts — the template now emits
+  `ModelContextProtocol` 1.2.0 while the snapshot pins 1.4.1 with no bump step; the
+  `.mcp/server.json` schema moved from the `2025-07-09` draft to `2025-10-17`; the template
+  no longer emits a namespace in `RandomNumberTools.cs`; and the quoted startup output does
+  not match what the server prints. Worth adding: MCP exposes tool names in **snake_case**,
+  not the PascalCase C# method name.
+- **Snapshot comparison:** Package version and `server.json` schema, as above.
+- **Snapshot updated:** No — filed as #572.
+
+> Note for future runs: piping stdin through `dotnet run` swallows the MCP server's stdout.
+> Drive the built `.exe` directly with redirected stdin/stdout.
+
+### Part 6 - Enhanced MCP Server
+
+- **What was run:** `dotnet build -c Release` on the snapshot, then the same stdio harness.
+- **Result:** 0 warnings. All three tools verified: `get_order_details("12345")` returns the
+  John Doe order, `get_product_inventory("Hiking Boots")` returns SKU HB-003, and
+  `search_orders_by_customer("John")` returns two orders. Clean shutdown.
+- **Documentation clarity:** All four "Additional Resources" links are 404.
+- **Snapshot updated:** No.
+
+### Part 7 - MCP Publishing
+
+Failed the original run and **passes the retest after #583**. The original findings are kept
+because they explain what the rewrite is defending against.
+
+- **What was run (original, at `aad12bd`):** `dotnet pack -c Release` against the untouched
+  Part 5 project, then applied Step 1's replacement `.csproj` to a copy and packed again.
+- **Result (original):**
+  - The replacement `.csproj` **did not compile** — it omitted
+    `<ImplicitUsings>enable</ImplicitUsings>`, producing two `CS0246` errors on `Task<>`.
+  - After adding only that back, the resulting package declared `packageType DotnetTool`
+    **only** — not `McpServer` — and contained **no `.mcp/server.json`**, because the
+    replacement dropped `<PackageType>`, `<RuntimeIdentifiers>`, `<SelfContained>`,
+    `<PublishSingleFile>` and the `server.json` pack item. Following Part 7 literally could
+    not produce a usable MCP server package.
+  - Against the unmodified template, `dotnet pack` produced **seven** packages, not the
+    single `.nupkg` Step 3 assumed.
+  - Step 1 set `<ToolCommandName>weather-mcp-server</ToolCommandName>` but Step 3 tested
+    `my-mcp-server --help`.
+  - Steps 1 and 3 told the attendee to edit and build inside the committed Part 5 snapshot.
+- **Retest at `b7d43cf` (after #583):** Followed the rewritten README literally, stopping
+  before Step 4 since publishing is out of scope.
+  - Step 1 now fills in the metadata block instead of replacing the file, so all four
+    load-bearing settings survive. `dotnet pack -c Release` succeeds — no `CS0246`.
+  - Produces **exactly seven** packages, names matching the README's list.
+  - The base package contains `README.md`, the nuspec, `.mcp\server.json` and
+    `tools\net10.0\any\DotnetToolSettings.xml`, and the nuspec declares **both**
+    `DotnetTool` and `McpServer` — the core of #571. `DotnetToolSettings.xml` maps all six
+    RIDs to their per-platform packages.
+  - Global install from the local source prints exactly the predicted
+    `You can invoke the tool using the following command: weather-mcp-server`; uninstall is
+    clean.
+  - Going beyond the README, driving the installed self-contained executable over stdio
+    returned `serverInfo: {"name":"MyMcpServer","version":"1.0.0.0"}`, listed all three
+    tools, and answered a real `tools/call get_current_weather` for Tokyo. The lab now
+    produces a genuinely installable, working server rather than just correct metadata.
+  - The new `publish-lab/` `.gitignore` entry works; `git status` stays clean after packing.
+  - Two nits, neither worth an issue: the "Expected contents" listing omits the OPC
+    boilerplate (`_rels/.rels` and the `.psmdcp`) that always appears, and the `.cmd` shim on
+    the PATH doesn't pass stdio through to a raw harness, though a real MCP client is fine.
+- **Documentation clarity:** Dead links unchanged and still tracked by #573 —
+  `modelcontextprotocol/awesome-mcp` 404s, `spec.modelcontextprotocol.io` is unreachable, and
+  the `server.json` `$schema` URL 404s (emitted by the template, not authored here).
+- **Snapshot updated:** N/A — no snapshot.
+
+### Part 8 - Agent Framework Basics
+
+- **What was run:** `dotnet new console` → `AgentApp`, the five packages from Step 1,
+  `Program.cs` per Step 3, then the three prompts from Step 4.
+- **Result:** Build 0 warnings. The agent invoked `GetOrderStatus` on its own for
+  `ORD-1001` and `ORD-1002`, and resolved *"How about ORD-1002?"* from conversation context.
+- **Documentation clarity:** No gaps found.
+- **Snapshot comparison:** `git diff --no-index` against the snapshot `Program.cs` reported
+  **zero differences**. Package versions matched the snapshot exactly. The only `.csproj`
+  delta is `UserSecretsId`.
+- **Snapshot updated:** No — nothing to change.
+
+### Part 9 - Adding AI to an Existing App
+
+- **What was run:** Built and ran the snapshot under Aspire, exercised the semantic search
+  endpoint directly, then drove the Blazor storefront in a browser.
+- **Result:** Everything the part teaches works.
+  - Build 0 warnings across all five projects.
+  - Keyword search for `warm at night` returns 0 results, as documented.
+  - All six queries from the README's distance table reproduced **exactly**, including both
+    rejections:
+
+    | Query | Result |
+    | --- | --- |
+    | `warm at night` | Four Season Sleeping Bag, Insulated Water Bottle, Merino Base Layer |
+    | `something for rainy weather` | Outdoor Rain Jacket, Two Person Tent, Trail Running Shoes |
+    | `keep my drink cold` | Insulated Water Bottle |
+    | `I need light for a cave` | Head Torch, Solar Powered Flashlight |
+    | `socket wrench` | *(nothing)* |
+    | `power tools for construction` | *(nothing)* |
+
+  - The Ask page answered the camping question with the Sleeping Bag and Tent, showing the
+    three source products underneath, matching the screenshot in the README.
+  - `a socket wrench set for my car` returned the fixed "We do not stock anything that
+    matches that" string without calling the model.
+  - Step 3's Operations page is wired correctly and the local model is reachable, but it did
+    not return a summary within the test window. Measuring the endpoint directly, warm and
+    with the model already loaded, `Phi-4-mini-instruct-generic-gpu` runs at roughly **0.15
+    tokens/second** — 11 completion tokens in 78s, 29 in 155s — against a README that promises
+    "a few seconds" for warm requests. One summarize-style prompt returned `finish_reason:
+    stop` with **zero** completion tokens and empty content, reproduced twice, so the page can
+    render blank even after the wait. The cause is model choice rather than a workshop defect:
+    the README recommends a 1.5B NPU build, while this machine has a 3.8B `generic-gpu` build
+    loaded. But the README's "any small model will do" invites exactly that substitution, so
+    the guidance needs sharpening. Filed #581.
+- **Documentation clarity:** The Foundry Local CLI commands are stale (`foundry service
+  status` and `foundry model run` no longer exist), and the suggested model is an NPU-only
+  variant.
+- **Snapshot comparison (original run):** The committed snapshot was the **finished** app, so
+  the README's premise — "five projects, none of which reference an AI package yet" — was
+  false of the folder it told you to open, and the motivating "watch keyword search fail"
+  moment could not happen. Part 9 was the only code part with no starting state.
+- **Retest at `b4917b2` (after #584):** `eShopLite-start/` now ships the AI-free solution and
+  the README points at it, with `eShopLite/` documented as the answer key.
+  - The starting state is genuinely clean: no AI package references anywhere, no
+    `Products/Ai/`, `Store/Ai/`, `Discovery.razor` or `Operations.razor`, and no leftover AI
+    usings. The only non-obvious `Products.csproj` entries are the
+    `SQLitePCLRaw.bundle_e_sqlite3` 3.0.4 and `Microsoft.OpenApi` 2.7.5 advisory pins, which
+    the new README note correctly flags as not-AI. Both solutions build Release with 0
+    warnings.
+  - The motivating moment reproduces. The starting app runs with no AI credentials in play —
+    which the finished app could not do — seeds 12 products, returns 3 results for `water`,
+    **0** for `warm at night`, and **404** on `/api/product/aisearch`.
+  - **Step 1 completes from the starting state**, which is the point of #570. Working from a
+    scratch copy: added the four packages, created `ProductVector.cs` and
+    `ProductSemanticSearch.cs` verbatim, set the secrets, applied the registrations and the
+    two-line seeding change, and added the endpoint. Build 0 warnings; startup logged
+    `Product search index is ready.`; and all six queries from the distance table came back
+    exactly as documented, with distances matching to three decimals except the cave query's
+    second value (0.654 vs 0.651), which the README already warns will drift.
+  - Moving "Configure credentials" to 1.4 is a real improvement — the earlier "watch keyword
+    search fail" run no longer asks for credentials the app doesn't use yet.
+  - Minor, not filed: `eShopLite-start` and `eShopLite` share the same `UserSecretsId` for
+    both `Products` and `Store`. Convenient, since setting secrets once covers both and
+    `-ApplyUserSecrets` keeps working, but the two folders aren't fully isolated.
+- **Snapshot updated:** No — #570 fixed by #584 and verified; #574 and #581 remain open.
+
+### Part 10 - Choosing Providers and Services
+
+- **What was run:** Documentation review, plus compiling the printed snippets and verifying
+  every cross-reference and package.
+- **Result:** Structure, cross-references and API shape all check out. The Part 11 anchor
+  resolves, issue #496 exists and is open, both `Microsoft.AI.Foundry.Local` and
+  `.WinML` exist on NuGet at 1.2.3, the alternative `--vector-store local` scaffold command
+  works, and the `FoundryLocalManager.Instance` → `GetCatalogAsync` → `GetModelAsync` →
+  `DownloadAsync` → `LoadAsync` → `StartWebServiceAsync` chain compiles against 1.2.3.
+- **Documentation clarity:** The snippets do not compile as printed. `AsIChatClient` and
+  `AsIEmbeddingGenerator` come from `Microsoft.Extensions.AI.OpenAI`, which the package list
+  never mentions (`CS1061`); the Foundry Local snippet references an undeclared `config`
+  variable (`CS0103`); and `Microsoft.AI.Foundry.Local` will not build on .NET 10 without an
+  explicit `<RuntimeIdentifier>`.
+- **Snapshot updated:** N/A.
+
+### Part 11 - Deployment
+
+- **What was run:** Verified `WithExternalHttpEndpoints()` in `AppHost.cs`, ran
+  `dotnet build GenAiLab.sln -c Release`, and reconciled the Part 4 scaffold against the
+  snapshot file-by-file. No `azd up`.
+- **Result:** 0 warnings, 0 errors.
+- **Documentation clarity:** The `$env:`-based alternative for the `openai` secured
+  parameter will not expand — `azd` reads the prompt as a literal string, so the attendee
+  submits `$env:WORKSHOP_AZURE_OPENAI_ENDPOINT` verbatim and only finds out at runtime,
+  after ~6 minutes of provisioning. Separately, the README shows the
+  `WithExternalHttpEndpoints()` call as a standalone statement while the snapshot chains it.
+- **Snapshot updated:** No.
+
+## Snapshot reconciliation
+
+| Snapshot | Differences found | Resolution |
+| --- | --- | --- |
+| `Part 02 - Build Chat App/ChatApp/` | Teaching comments and `UserSecretsId` only | No action |
+| `Part 03 - Add RAG/RagChatApp/` | `csproj` drops `Microsoft.Extensions.Logging.Console` carried in from Part 2; `checkpoints/medi-program.cs` matches my implementation and so carries the Step 3 crash | Filed #567, #568, #575 |
+| `Part 05 - MCP Server Basics/MyMcpServer/` | Template emits `ModelContextProtocol` 1.2.0 vs snapshot 1.4.1; `.mcp/server.json` on the older `2025-07-09` schema; template no longer emits a namespace | Filed #572 |
+| `Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/` | None | No action |
+| `Part 08 - Agent Framework Basics/AgentApp/` | **None.** `Program.cs` byte-identical; package versions identical; only `UserSecretsId` differs | No action |
+| `Part 09 - Adding AI to an Existing App/eShopLite/` | Snapshot is the finished app; `eShopLite-start/` added by #584 is the AI-free starting state | Fixed, verified |
+| `Part 11 - Deployment/GenAiLab/` | Identical file sets. Six files differ: `.sln` and both `launchSettings.json` by GUID/port, both `.csproj` by `UserSecretsId`, and `AppHost.cs` by exactly the `WithExternalHttpEndpoints()` call Part 11 asks for plus a comment | No action |
+
+> The skill's own part table lists Part 9's snapshot as `StoreApp/`; the repo has
+> `eShopLite/`. Worth correcting in `.github/skills/workshop-testing/SKILL.md`.
+
+## Issues
+
+All filed on the repo, with reproduction steps and suggested fixes:
+
+| # | Severity | Part | Title | Status |
+| --- | --- | --- | --- | --- |
+| #567 | **Critical** | 3 | Step 3 crashes on the workshop's own sample document (MEDI autolink) | Fixed by #579, verified |
+| #568 | High | 3 | Step 3 has no guard for failed ingestion, turning any failure into an unhandled crash | Fixed by #579, verified |
+| #569 | High | 3 | Step 2 chunking is a silent no-op on Windows (CRLF vs `"\n\n"`) | Fixed by #579, verified |
+| #570 | High | 9 | No "before" version of eShopLite — the only snapshot is the finished app | Fixed by #584, verified |
+| #571 | **Critical** | 7 | Step 1's replacement `.csproj` doesn't compile and strips the MCP packaging metadata | Fixed by #583, verified |
+| #572 | Medium | 5 | Template drift — package versions, `server.json` schema, namespace, startup output | Open |
+| #573 | Medium | 5/6/7/9/11 | Eight dead external links | Open |
+| #574 | Medium | 9 | Step 3 uses Foundry Local CLI commands that no longer exist | Open |
+| #575 | Medium | 3 | `NU1903` warnings on the MEDI path, and checkpoints are never built by CI | Open |
+| #577 | Medium | 10 | Provider snippets don't compile — missing package, undeclared `config`, RID requirement | Open |
+| #578 | Low | 11 | `azd` prompt `$env:` expansion, and a README/snapshot style mismatch | Open |
+| #580 | High | 4 | Docker-free path never gets the `gpt-4o-mini` → `gpt-5-mini` fix, and the comparison table says it already has it | Fixed in this branch, verified |
+| #581 | Medium | 9 | Warm local-model responses took 78–155s, not the "few seconds" the README promises | Open |
+| #576 | — | all | Summary issue for this run | Open |
+
+## Recommended documentation improvements
+
+In priority order for the next delivery. **Items 1-3 and 5 are done** — #579 and #583 fixed
+them and the retests confirm; they are kept here as a record of what shipped.
+
+1. ~~**`Part 03 - Add RAG/RagChatApp/sample-docs/contoso-trailblazer-3000.md`** — drop the
+   angle brackets around the support address.~~ Done in #579.
+2. ~~**`Part 03 - Add RAG/README.md` Step 2.2**, plus `RagChatApp/Program.cs` and
+   `checkpoints/manual-program.cs` — normalize line endings before the split, and add a
+   `.gitattributes` rule.~~ Done in #579, which used `ReplaceLineEndings("\n")` and pinned
+   `**/sample-docs/*.md text eol=lf`. Both defenses verified independently.
+3. ~~**`Part 03 - Add RAG/README.md` Step 3.4** — guard on `result.Succeeded` before reading
+   `writer.VectorStoreCollection`, and stop with a clear message when nothing ingested.~~
+   Done in #579.
+4. ~~**`Part 04 - AI Web Chat Template/README.md` lines 100 and 112** — the Docker-free path
+   needs the `gpt-4o-mini` → `gpt-5-mini` edit, which currently sits inside a step that
+   section tells readers to skip; and the comparison table describes the corrected code
+   rather than what the template emits. This path is the fallback for attendees whose Docker
+   won't start, so it fails at the worst possible moment.~~ Done in this branch: the
+   Docker-free path became a standalone section with its own complete configuration,
+   including the model-name edit shown in place. Verified by re-scaffolding and running it.
+5. ~~**`Part 07 - MCP Publishing/README.md` Step 1** — stop replacing the `.csproj`. Show the
+   metadata as additions to the template's file, and explain why `<PackageType>McpServer</PackageType>`
+   and the `.mcp/server.json` pack item must survive.~~ Done in #583, verified.
+6. ~~**`Part 09 - Adding AI to an Existing App/`** — add an `eShopLite-start/` folder with the
+   AI removed, and point the README at it.~~ Done in #584, verified.
+7. **`Part 10 .../README.md`** — add `Microsoft.Extensions.AI.OpenAI` to the package lists
+   and `using Microsoft.Extensions.AI;` to the snippets; replace `config.Web.Urls` with
+   something the attendee can actually resolve.
+8. **`Part 09 .../README.md` Step 3.2** — `foundry server status`, `foundry run <model>`,
+   unqualified `qwen2.5-1.5b`, and promote the "warm the model first" note to a warning that
+   names the real variable: parameter count *and* execution-provider variant, not just
+   "any small model."
+9. **Dead links** across Parts 5, 6, 7, 9 and 11 — consider adding a link checker to CI
+   alongside the existing markdownlint workflow.
+
+## Summary
+
+**The workshop has no failing parts left.**
+
+Nine of eleven parts pass outright; the other two pass with issues. Part 8 is flawless — a
+byte-identical snapshot match with the agent behaving exactly as documented. Part 11's
+reconciliation against Part 4 is as tight as it could reasonably be: identical file sets, and
+the only functional difference is the single line Part 11 asks you to add. All seven CI
+targets build with **zero warnings**.
+
+The two parts that failed the original run are both fixed and re-verified. #579 removed the
+autolink that crashed Part 3 Step 3 for every attendee, normalized line endings so Step 2
+actually chunks on Windows, and added a guard that turns an ingestion failure into a readable
+message instead of a second unhandled exception. #583 stopped Part 7 from replacing the
+template's `.csproj`, so the lab now packs successfully and produces an MCP server package
+that a client will actually recognise — confirmed by driving the installed executable over
+stdio.
+
+Part 4 was reorganized after rehearsal feedback that its configuration steps were unclear and
+came too late. All four configuration changes now sit in one step immediately after
+scaffolding, the connection-string secret is documented for Visual Studio as well as the CLI
+and says plainly which project owns it, and the Docker-free path became a self-contained
+section with its own complete configuration. That last change closes #580: the path that
+attendees fall back to *because Docker wouldn't start* no longer ships a deployment name their
+resource doesn't have. Both paths were re-run end to end afterwards and produced grounded,
+cited answers. Part 4 keeps no snapshot of its own — `Part 11 - Deployment/GenAiLab/` is the
+finished Part 4 plus one line — and that is now said explicitly in four places rather than
+left implicit.
+
+Part 9's three AI features all work exactly as documented, reproducing the README's
+distance table verbatim, and #584 supplied the missing starting point: `eShopLite-start/` is
+genuinely AI-free, runs without credentials, and Step 1 completes from it to produce working
+semantic search with distances matching the published table. Its optional local-model step
+works but is far slower than the README implies on anything other than the recommended small
+NPU build.
+
+Everything else is documentation drift: stale CLI commands, snippets missing a package
+reference, and eight dead links.


### PR DESCRIPTION
Fixes #580.

Rehearsal feedback was that Part 4's configuration steps were unclear and came too late. An attendee scaffolded, ran the app, and hit an Azure provisioning prompt before the README had told them how to point at an existing resource — and the connection string was documented only as a CLI command, ~250 lines into the part, buried after a long code walkthrough.

## Configuration now comes before the first run

The part is reordered around one idea: get it configured, get it running, *then* read the code.

- **New Step 2, "Configure it before you run it"**, sits immediately after scaffolding and opens with a table of the four changes and an explicit "do this before you press F5."
  - 2.1 packages → 2.2 `AddConnectionString` swap → 2.3 deployment name → 2.4 the secret → 2.5 build check
- **Step 2.2** now shows the exact `AddAzureOpenAI` block to delete instead of describing it.
- **Step 2.4 works for Visual Studio.** Right-click `GenAiLab.AppHost` → **Manage User Secrets**, with the literal `secrets.json` to paste, alongside the CLI command and a `list` verification. An IMPORTANT states that the secret belongs to **AppHost, not Web** — putting it on the wrong project fails silently, which is a miserable thing to debug.
- **The code walkthrough moved to Step 5**, after the app works, and now shows the AppHost as the attendee actually left it rather than the template's version they just deleted.
- Step 3 gained a troubleshooting tip: an Azure provisioning prompt means 2.2 didn't take.

## Docker-free path (#580)

It was a sub-bullet inside Step 1 that handed readers off to Step 3 for the `gpt-4o-mini` → `gpt-5-mini` edit — a step that same section also told them to skip. So they never made the edit, while the comparison table claimed the path already used `gpt-5-mini`.

This is the path people take **because Docker wouldn't start**, so it failed at the worst possible moment. It's now a standalone end-of-part section with a complete configuration of its own, showing the edit in place against what the template actually emits, and warning that skipping it means the app builds and starts fine and then 404s on the first message. The comparison table gained a **Credentials** row, since the two paths genuinely differ there (`ConnectionStrings:openai` on the AppHost vs `AzureOpenAI:Endpoint` + `AzureOpenAI:Key` on the app).

## Stale Qdrant data volume

Hit while rehearsing: run the app, update packages, run again, and `vectordb` never starts. Two causes, both deliberate settings:

```csharp
.WithDataVolume()                              // storage survives shutdown
.WithLifetime(ContainerLifetime.Persistent);   // container survives shutdown
```

Bumping Aspire bumps the Qdrant image, and old storage can be incompatible — but `ContainerLifetime.Persistent` compounds it, because the old container is reused rather than recreated, so it never picks up the new image. Deleting only the volume wouldn't have fixed it.

New "Qdrant won't start after updating packages" section explains both, gives `--filter` commands so attendees can find their own generated names, notes the Docker Desktop equivalent, and reassures that nothing of value is lost. Part 11 links to it, since it runs the same solution.

## The completed code is now findable

Part 4 has no snapshot of its own by design — `Part 11 - Deployment/GenAiLab/` is a finished Part 4 plus the single `WithExternalHttpEndpoints()` line. That was implicit knowledge. It's now stated in the Part 4 README, the Part 11 README, the root README, and the snapshot's own template-generated README, which previously pointed readers at Azure provisioning that the workshop version has deliberately removed.

Also: `setup-workshop-credentials.ps1` now targets `eShopLite-start` as well as `eShopLite`.

## Verification

Everything here was run against the live workshop resource, not just read.

| Check | Result |
| --- | --- |
| `GenAiLab.sln` Release build | 0 warnings, 0 errors |
| AppHost start | No provisioning prompt; `vectordb` + `markitdown` up |
| Aspire chat | Grounded answer, 2 working citations into the sample PDF |
| Docker-free re-scaffold, new section only | 0 warnings; same answer, same 2 citations |
| Volume recovery | `docker rm -f` then `docker volume rm` both succeed; re-run recreates and re-ingests |

Two notes from doing it:

- The cleanup command **order matters** — Docker refuses to remove a volume still attached to a container, so the documented order is the working one.
- `GenAiLab.AppHost` had **no** user secret set at all, because #566 re-scaffolded it and changed its `UserSecretsId`. Re-running `setup-workshop-credentials.ps1 -ApplyUserSecrets` fixes it. Worth knowing whenever that project is regenerated.

Also includes `docs/testing/workshop-test-report-2026-07-27.md`, the report for the full end-to-end run this and the four earlier fix PRs came out of, indexed in `docs/README.md`.

Docs only — no snapshot code changed, so the eight CI build targets are untouched. markdownlint is clean, and all internal and cross-file anchors resolve.