### PR TITLE
Part 5: install the MCP server template explicitly and fix the Visual Studio config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,13 +11,8 @@ Everything targets **.NET 10** and uses **Microsoft Foundry (Azure OpenAI)** as 
 | 01 - Setup | — | README only |
 | 02 - Build Chat App | `ChatApp/` | Console app built by hand (`dotnet new console`) |
 | 03 - Add RAG | `RagChatApp/` | Continues from Part 2; `checkpoints/` holds two alternate `Program.cs` paths (manual cosine similarity, and MEDI + SqliteVec). `checkpoints/verify/` holds compile-only projects so CI type-checks both checkpoints — the snapshot itself is the Step 2 manual path |
-<<<<<<< HEAD
-| 04 - AI Web Chat Template | — | README only; scaffolds `GenAiLab` with `dotnet new aichatweb` |
-| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver` (template from `Microsoft.McpServer.ProjectTemplates`); `RandomNumberTools` + `WeatherTools` |
-=======
 | 04 - AI Web Chat Template | *(shares `Part 11 - Deployment/GenAiLab/`)* | README only in this folder; scaffolds `GenAiLab` with `dotnet new aichatweb`. The completed code deliberately lives in Part 11 rather than being duplicated here — keep both READMEs saying so |
-| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver`; `RandomNumberTools` + `WeatherTools` |
->>>>>>> origin/main
+| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver` (template from `Microsoft.McpServer.ProjectTemplates`); `RandomNumberTools` + `WeatherTools` |
 | 06 - Enhanced MCP Server | `ContosoOrdersMcpServer/` | Optional/bonus. Exploration of an existing snapshot — the README does **not** ask the user to scaffold it |
 | 07 - MCP Publishing | — | Optional/bonus, README only |
 | 08 - Agent Framework Basics | `AgentApp/` | `dotnet new console` + `Microsoft.Agents.AI` |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ Everything targets **.NET 10** and uses **Microsoft Foundry (Azure OpenAI)** as 
 | 02 - Build Chat App | `ChatApp/` | Console app built by hand (`dotnet new console`) |
 | 03 - Add RAG | `RagChatApp/` | Continues from Part 2; `checkpoints/` holds two alternate `Program.cs` paths (manual cosine similarity, and MEDI + SqliteVec). `checkpoints/verify/` holds compile-only projects so CI type-checks both checkpoints — the snapshot itself is the Step 2 manual path |
 | 04 - AI Web Chat Template | — | README only; scaffolds `GenAiLab` with `dotnet new aichatweb` |
-| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver`; `RandomNumberTools` + `WeatherTools` |
+| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver` (template from `Microsoft.McpServer.ProjectTemplates`); `RandomNumberTools` + `WeatherTools` |
 | 06 - Enhanced MCP Server | `ContosoOrdersMcpServer/` | Optional/bonus. Exploration of an existing snapshot — the README does **not** ask the user to scaffold it |
 | 07 - MCP Publishing | — | Optional/bonus, README only |
 | 08 - Agent Framework Basics | `AgentApp/` | `dotnet new console` + `Microsoft.Agents.AI` |
@@ -45,7 +45,7 @@ Markdown is linted by `.github/workflows/markdownlint.yml` using `.markdownlint.
 ## Conventions
 
 - **Snapshots must match the README.** If you change instructions in a `README.md`, update that part's snapshot code in the same change, and vice versa.
-- **Projects are created with `dotnet new`,** never by hand-authoring a `.csproj`. Templates come from `Microsoft.Extensions.AI.Templates` and `Aspire.ProjectTemplates`.
+- **Projects are created with `dotnet new`,** never by hand-authoring a `.csproj`. Templates come from `Microsoft.Extensions.AI.Templates`, `Microsoft.McpServer.ProjectTemplates`, and `Aspire.ProjectTemplates`.
 - **Scaffold, then update packages.** Templates lag the current package versions. After `dotnet new`, bump to current and record the bump as an explicit README step so the snapshot and the instructions stay in sync. Aspire is pinned at **13.4.6** across the repo; note that the `<Sdk Name="Aspire.AppHost.Sdk" />` element must be edited by hand because `dotnet add package` only manages `<PackageReference>` items.
 - The Part 4 scaffold command is fixed and load-bearing for later parts:
   `dotnet new aichatweb --provider azureopenai --vector-store qdrant --aspire --name GenAiLab --output GenAiLab`

--- a/.github/skills/workshop-testing/SKILL.md
+++ b/.github/skills/workshop-testing/SKILL.md
@@ -21,6 +21,7 @@ Complete the workshop the way an attendee would — follow each `Part N - */READ
 .\.github\scripts\setup-workshop-credentials.ps1 -ApplyUserSecrets
 dotnet --list-sdks                                  # expect 10.0.x
 dotnet new install Microsoft.Extensions.AI.Templates
+dotnet new install Microsoft.McpServer.ProjectTemplates
 docker --version                                    # only needed for Parts 4 and 11
 ```
 
@@ -38,7 +39,7 @@ The samples hardcode the deployment names `gpt-5-mini` and `text-embedding-3-sma
 | 2 - Build Chat App | `dotnet new console -n ChatApp`, add packages and code per README. Run it: chat, streaming, structured output | `Part 02 - Build Chat App/ChatApp/` |
 | 3 - Add RAG | Continue from your Part 2 app (README says copy it). Verify retrieval answers from `manuals/`. Also check the two `checkpoints/*.cs` variants still compile against the described packages | `Part 03 - Add RAG/RagChatApp/` |
 | 4 - AI Web Chat Template | Scaffold with the exact command in the README (`--provider azureopenai --vector-store qdrant --aspire --name GenAiLab`). Run via `GenAiLab.AppHost`. Also sanity-check the documented Docker-free `--vector-store local` path | Compare against `Part 11 - Deployment/GenAiLab/` |
-| 5 - MCP Server Basics | `dotnet new mcpserver -n MyMcpServer`, add `WeatherTools` per README. Keep the template's `RandomNumberTools` | `Part 05 - MCP Server Basics/MyMcpServer/` |
+| 5 - MCP Server Basics | `dotnet new install Microsoft.McpServer.ProjectTemplates`, then `dotnet new mcpserver -n MyMcpServer`, add `WeatherTools` per README. Keep the template's `RandomNumberTools` | `Part 05 - MCP Server Basics/MyMcpServer/` |
 | 6 - Enhanced MCP Server *(bonus)* | Exploration only — build and run the existing snapshot, review the README's business-integration guidance | `Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/` |
 | 7 - MCP Publishing *(bonus)* | Documentation review only. **Do not publish anything** | — |
 | 8 - Agent Framework Basics | `dotnet new console` → `AgentApp`, add `Microsoft.Agents.AI` per README. Verify the agent runs and can call the Part 5 weather tool if the README wires that up | `Part 08 - Agent Framework Basics/AgentApp/` |

--- a/Part 05 - MCP Server Basics/MyMcpServer/.mcp.json
+++ b/Part 05 - MCP Server Basics/MyMcpServer/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "servers": {
+    "MyMcpServer": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "MyMcpServer.csproj"
+      ]
+    }
+  }
+}

--- a/Part 05 - MCP Server Basics/MyMcpServer/MyMcpServer.slnx
+++ b/Part 05 - MCP Server Basics/MyMcpServer/MyMcpServer.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="MyMcpServer.csproj" />
+</Solution>

--- a/Part 05 - MCP Server Basics/README.md
+++ b/Part 05 - MCP Server Basics/README.md
@@ -59,9 +59,31 @@ Before starting this part, ensure you have:
 - ✅ **Visual Studio Code** with GitHub Copilot extension, or **Visual Studio 2026** (see Step 7)
 - ✅ **Active GitHub Copilot subscription**
 
-## Step 1: Verify the MCP Server Template
+## Step 1: Install the MCP Server Template
 
-The MCP server template is included in the `Microsoft.Extensions.AI.Templates` package that you installed in Part 4. Let's verify it's available:
+The MCP server template ships in its own NuGet package,
+**`Microsoft.McpServer.ProjectTemplates`** — not in the
+`Microsoft.Extensions.AI.Templates` package you installed in Part 4, which
+provides only the `aichatweb` template.
+
+1. **Install the template package**:
+
+   ```powershell
+   dotnet new install Microsoft.McpServer.ProjectTemplates
+   ```
+
+   You should see it report the installed template:
+
+   ```text
+   Success: Microsoft.McpServer.ProjectTemplates@1.2.1 installed the following templates:
+   Template Name   Short Name  Language  Tags
+   --------------  ----------  --------  -------------
+   MCP Server App  mcpserver   [C#]      Common/AI/MCP
+   ```
+
+   If it is already present you will see *"is already installed, it will be
+   replaced with latest version"* first. That is fine — the command is safe to
+   re-run and simply moves you to the current version.
 
 1. **Verify the template is available and see its options**:
 
@@ -72,16 +94,22 @@ The MCP server template is included in the `Microsoft.Extensions.AI.Templates` p
    You should see help output showing the MCP Server template options, including:
 
    ```text
-   MCP Server (C#)
+   MCP Server App (C#)
    Author: Microsoft
-   Description: A template for creating a Model Context Protocol server...
-   
+
+   Usage:
+     dotnet new mcpserver [options] [template options]
+
    Options:
      -n, --name <name>           The name for the output being created...
      -o, --output <output>       Location to place the generated output...
    ```
 
-   > **Note**: If you get an error that the template is not found, make sure you have the .NET 10.0 SDK or later installed and the templates were installed correctly in Part 4. You can reinstall with: `dotnet new install Microsoft.Extensions.AI.Templates`
+> [!NOTE]
+> Some .NET SDK installations bundle this template, so `dotnet new mcpserver` may
+> already work before you install anything. Run the install command anyway — it
+> is how you get the current version, and it is the only reliable way to get the
+> template if your SDK does not carry it.
 
 ## Step 2: Create Your First MCP Server
 
@@ -99,10 +127,11 @@ Now let's create a new MCP server project using the template:
    dotnet new mcpserver -n MyMcpServer
    ```
 
-   This command creates a new MCP server project with:
-   - Basic MCP server infrastructure  
-   - Example `RandomNumberTools` implementation
-   - Configuration files for VS Code integration
+   This creates a project containing:
+   - `Program.cs` — the MCP server host, using stdio transport
+   - `Tools/RandomNumberTools.cs` — an example tool
+   - `.mcp/server.json` — server metadata used when packaging (see [Part 7](../Part%2007%20-%20MCP%20Publishing/README.md))
+   - `README.md` — the template's own notes
 
 3. **Navigate to the new project**:
 
@@ -119,8 +148,8 @@ Now let's create a new MCP server project using the template:
 
 > [!NOTE]
 > If **MCP Server** does not appear in the **Create a new project** dialog,
-> install the templates from a terminal with
-> `dotnet new install Microsoft.Extensions.AI.Templates`, then restart Visual
+> install the template from a terminal with
+> `dotnet new install Microsoft.McpServer.ProjectTemplates`, then restart Visual
 > Studio 2026 and search again.
 
 ## Step 3: Understanding the Generated Project Structure
@@ -160,8 +189,6 @@ The template generates a simple `RandomNumberTools` class with a `GetRandomNumbe
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 
-namespace MyMcpServer.Tools;
-
 /// <summary>
 /// Sample MCP tools for demonstration purposes.
 /// These tools can be invoked by MCP clients to perform various operations.
@@ -178,6 +205,19 @@ internal class RandomNumberTools
     }
 }
 ```
+
+> [!NOTE]
+> The template emits this file with **no namespace declaration**, so the class
+> lands in the global namespace. The tools you add next use
+> `namespace MyMcpServer.Tools;`, which is the convention the completed snapshot
+> in this folder follows. To match that snapshot exactly, add the same namespace
+> line to `RandomNumberTools.cs`:
+>
+> ```csharp
+> namespace MyMcpServer.Tools;
+> ```
+>
+> Either way the project compiles and both tools are discovered.
 
 We'll add weather functionality alongside this, keeping both tools available.
 
@@ -374,13 +414,20 @@ If you prefer to use **Visual Studio 2026** instead of VS Code, you can configur
 
 ### Configuration Steps
 
-1. **Navigate to your solution directory** (where the `.sln` file is located):
+1. **Make sure you have a solution file.** Visual Studio only discovers `.mcp.json`
+   relative to a *solution* directory, so opening the bare `.csproj` is not enough.
+   From your `MyMcpServer` folder:
 
    ```powershell
-   cd "Part 11 - Deployment\GenAiLab"  # or your main solution directory
+   cd MyMcpServer
+   dotnet new sln --name MyMcpServer --format slnx
+   dotnet sln add MyMcpServer.csproj
    ```
 
-2. **Create the MCP configuration file** `.mcp.json` in your solution directory:
+   > **NOTE:** The committed snapshot already includes `MyMcpServer.slnx`, so if you
+   > are exploring the snapshot rather than your own project you can skip this.
+
+2. **Create the MCP configuration file** `.mcp.json` next to the solution file:
 
    ```json
    {
@@ -391,18 +438,20 @@ If you prefer to use **Visual Studio 2026** instead of VS Code, you can configur
          "args": [
            "run",
            "--project",
-           "../../Part 05 - MCP Server Basics/MyMcpServer"
+           "MyMcpServer.csproj"
          ]
        }
      }
    }
    ```
 
-3. **Add the configuration file to your solution** (optional but recommended):
-   - Right-click on the solution in **Solution Explorer**
-   - Select **Add > Existing Item**
-   - Navigate to and select the `.mcp.json` file
-   - Choose **Add as Link** to include it in your solution
+   The `--project` path is relative to the folder holding `.mcp.json`. If you put the
+   configuration in a different solution's directory, adjust the path to point at
+   `MyMcpServer.csproj` from there.
+
+3. **Open the solution in Visual Studio** (`MyMcpServer.slnx`). Visual Studio reads
+   `.mcp.json` from the solution directory on load. Adding the file to the solution
+   via **Add > Existing Item** is optional, but makes it easier to find later.
 
 4. **Enable Agent Mode in GitHub Copilot**:
    - Open the **GitHub Copilot Chat** window
@@ -608,11 +657,12 @@ When your MCP server runs, you might see log output in VS Code's Output panel:
 
 ### Development Workflow
 
-1. **Create** MCP server project with `dotnet new mcpserver`
-2. **Implement** custom tools with proper attributes
-3. **Configure** VS Code or Visual Studio 2026 to use your server
-4. **Test** with GitHub Copilot conversations
-5. **Iterate** and improve based on AI usage patterns
+1. **Install** the template with `dotnet new install Microsoft.McpServer.ProjectTemplates`
+2. **Create** MCP server project with `dotnet new mcpserver`
+3. **Implement** custom tools with proper attributes
+4. **Configure** VS Code or Visual Studio 2026 to use your server
+5. **Test** with GitHub Copilot conversations
+6. **Iterate** and improve based on AI usage patterns
 
 > **🚀 Advanced Challenge**: If you're moving quickly and want an extra challenge, check out the [official Microsoft quickstart guide](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/build-mcp-server) which shows how to publish your MCP server to NuGet for others to use. This is covered in more detail in Part 7, but the quickstart provides a streamlined approach if you want to try it now!
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Get up to speed quickly with AI app building in .NET. This workshop covers AI ap
 
 - Visual Studio 2026 or VS Code
 - .NET AI Web Chatbot template installed (`dotnet new install Microsoft.Extensions.AI.Templates`; walked through in Part 4)
+- MCP Server template installed (`dotnet new install Microsoft.McpServer.ProjectTemplates`; walked through in Part 5)
 - .NET 10.0 SDK or later
 - Docker Desktop or Podman (recommended for the full Qdrant + Aspire path in Part 4)
 - Azure subscription with access to [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) (Azure OpenAI), the primary AI provider
@@ -34,7 +35,7 @@ Without Docker, you can still complete Parts 1-10, including the main chat, RAG,
 - .NET 10.0 SDK - Required for MCP development
 - Visual Studio Code
 - GitHub Copilot subscription (required for MCP testing)
-- `Microsoft.Extensions.AI.Templates` package
+- `Microsoft.McpServer.ProjectTemplates` package (`dotnet new install Microsoft.McpServer.ProjectTemplates`; walked through in Part 5)
 
 ### Optional but Recommended
 


### PR DESCRIPTION
## Part 5: install the MCP template explicitly, and make the Visual Studio config actually work

Two related fixes for Part 5, plus the Visual Studio MCP config from the branch's first commit.

### 1. The README named the wrong template package

Step 1 told attendees the `mcpserver` template ships in `Microsoft.Extensions.AI.Templates`. It does not — that package provides **only** `aichatweb`. The template comes from **`Microsoft.McpServer.ProjectTemplates`**.

This matters because the template is *also* bundled with some SDK builds but not others:

| SDK | Bundled template |
| --- | --- |
| `10.0.10` | `microsoft.mcpserver.projecttemplates.10.0.10.0.10.nupkg` present |
| `10.0.9` | absent |

So `dotnet new mcpserver` works for some attendees and fails for others with no obvious cause. Step 1 is now **"Install the MCP Server Template"** and runs the install explicitly, with a note explaining the "already installed, will be replaced" message people will see if they have a bundled copy.

### 2. The Visual Studio instructions could not work as written

Visual Studio only discovers `.mcp.json` relative to a **solution** directory. Step 7 previously said to `cd "Part 11 - Deployment\GenAiLab"` and put the config there with a `../../` path back to Part 5 — which is both surprising and wrong for anyone who just opened the Part 5 project.

Step 7 now creates a solution file first, and this PR ships `MyMcpServer.slnx` next to the `.mcp.json` added in `ae0b1db` so the committed snapshot works when opened in VS.

### 3. Smaller README corrections found while verifying

- The Step 2 file list claimed the template emits "configuration files for VS Code integration". It emits no `.vscode/` anything. Replaced with the actual four items.
- The Step 3 `RandomNumberTools` listing showed a `namespace MyMcpServer.Tools;` line the template does not emit. Added a NOTE that attendees can add it to match the snapshot, and that it compiles either way.
- Corrected the `-h` sample output (real template name is "MCP Server App"; it prints a `Usage:` line, not `Description:`).

### 4. Other files that named the wrong package

`README.md` (root), `.github/copilot-instructions.md`, and `.github/skills/workshop-testing/SKILL.md` all stated or implied `Microsoft.Extensions.AI.Templates` for MCP. Updated.

## Verification

Ran the whole part as an attendee from a clean scaffold in a scratch directory:

- Installed `Microsoft.McpServer.ProjectTemplates` (1.2.1) per the new Step 1.
- `dotnet new mcpserver`, then applied every README step verbatim.
- `dotnet build -c Release` → **0 warnings, 0 errors**.
- Drove the server over stdio: `initialize` OK, `tools/list` returns all **3** tools (`get_random_number`, `get_weather_forecast`, `get_current_weather`), and `tools/call get_current_weather` for Seattle returns real data.
- Diffed the result against the snapshot: `Program.cs`, `Tools/RandomNumberTools.cs`, and `Tools/WeatherTools.cs` are **identical**.
- Confirmed the documented `dotnet new sln --format slnx` + `dotnet sln add` commands reproduce the committed `MyMcpServer.slnx` byte-for-byte.
- markdownlint clean on every edited file.

## Not addressed here

The scaffold still emits `ModelContextProtocol` **1.2.0** while the snapshot pins **1.4.1**, and the README never tells attendees to bump it. That is existing issue #572 and is left alone to keep this PR scoped.