### PR TITLE
Fix workshop credential setup and deployment docs

### DIFF
--- a/.github/scripts/setup-workshop-credentials.ps1
+++ b/.github/scripts/setup-workshop-credentials.ps1
@@ -190,25 +190,13 @@ function Write-WorkshopUserSecrets {
         Write-Host "  [missing] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost (Parts 4 and 11)" -ForegroundColor Yellow
     }
 
-    # Part 4 scaffolds a GenAiLab app in the repo root when the workshop is tested from scratch.
-    # Apply the same Azure OpenAI secrets there when the scaffold exists.
-    $scaffoldedGenAiLab = Join-Path $repoRoot 'GenAiLab'
-    if (Test-Path $scaffoldedGenAiLab) {
-        $scaffoldedRootProject = Join-Path $scaffoldedGenAiLab 'GenAiLab.csproj'
-        if (Test-Path $scaffoldedRootProject) {
-            dotnet user-secrets init --project $scaffoldedGenAiLab 2>&1 | Out-Null
-            $ok = Set-ProjectSecret $scaffoldedGenAiLab 'AzureOpenAI:Endpoint' $env:WORKSHOP_AZURE_OPENAI_ENDPOINT
-            $ok = (Set-ProjectSecret $scaffoldedGenAiLab 'AzureOpenAI:Key' $env:WORKSHOP_AZURE_OPENAI_KEY) -and $ok
-            if ($ok) { Write-Host "  [ok] GenAiLab scaffold" -ForegroundColor Green }
-        }
-
-        $scaffoldedAppHost = Join-Path $scaffoldedGenAiLab 'GenAiLab.AppHost'
-        if (Test-Path $scaffoldedAppHost) {
-            dotnet user-secrets init --project $scaffoldedAppHost 2>&1 | Out-Null
-            $connection = "Endpoint=$($env:WORKSHOP_AZURE_OPENAI_ENDPOINT);Key=$($env:WORKSHOP_AZURE_OPENAI_KEY)"
-            if (Set-ProjectSecret $scaffoldedAppHost 'ConnectionStrings:openai' $connection) {
-                Write-Host "  [ok] GenAiLab scaffold AppHost" -ForegroundColor Green
-            }
+    # Workshop tests scaffold Part 4 under test-workspace/GenAiLab.
+    $scaffoldedAppHost = Join-Path $repoRoot 'test-workspace/GenAiLab/GenAiLab.AppHost'
+    if (Test-Path $scaffoldedAppHost) {
+        dotnet user-secrets init --project $scaffoldedAppHost 2>&1 | Out-Null
+        $connection = "Endpoint=$($env:WORKSHOP_AZURE_OPENAI_ENDPOINT);Key=$($env:WORKSHOP_AZURE_OPENAI_KEY)"
+        if (Set-ProjectSecret $scaffoldedAppHost 'ConnectionStrings:openai' $connection) {
+            Write-Host "  [ok] test-workspace/GenAiLab/GenAiLab.AppHost" -ForegroundColor Green
         }
     }
 }

--- a/.github/scripts/setup-workshop-credentials.ps1
+++ b/.github/scripts/setup-workshop-credentials.ps1
@@ -189,6 +189,28 @@ function Write-WorkshopUserSecrets {
     else {
         Write-Host "  [missing] Part 11 - Deployment/GenAiLab/GenAiLab.AppHost (Parts 4 and 11)" -ForegroundColor Yellow
     }
+
+    # Part 4 scaffolds a GenAiLab app in the repo root when the workshop is tested from scratch.
+    # Apply the same Azure OpenAI secrets there when the scaffold exists.
+    $scaffoldedGenAiLab = Join-Path $repoRoot 'GenAiLab'
+    if (Test-Path $scaffoldedGenAiLab) {
+        $scaffoldedRootProject = Join-Path $scaffoldedGenAiLab 'GenAiLab.csproj'
+        if (Test-Path $scaffoldedRootProject) {
+            dotnet user-secrets init --project $scaffoldedGenAiLab 2>&1 | Out-Null
+            $ok = Set-ProjectSecret $scaffoldedGenAiLab 'AzureOpenAI:Endpoint' $env:WORKSHOP_AZURE_OPENAI_ENDPOINT
+            $ok = (Set-ProjectSecret $scaffoldedGenAiLab 'AzureOpenAI:Key' $env:WORKSHOP_AZURE_OPENAI_KEY) -and $ok
+            if ($ok) { Write-Host "  [ok] GenAiLab scaffold" -ForegroundColor Green }
+        }
+
+        $scaffoldedAppHost = Join-Path $scaffoldedGenAiLab 'GenAiLab.AppHost'
+        if (Test-Path $scaffoldedAppHost) {
+            dotnet user-secrets init --project $scaffoldedAppHost 2>&1 | Out-Null
+            $connection = "Endpoint=$($env:WORKSHOP_AZURE_OPENAI_ENDPOINT);Key=$($env:WORKSHOP_AZURE_OPENAI_KEY)"
+            if (Set-ProjectSecret $scaffoldedAppHost 'ConnectionStrings:openai' $connection) {
+                Write-Host "  [ok] GenAiLab scaffold AppHost" -ForegroundColor Green
+            }
+        }
+    }
 }
 
 Write-Host ''

--- a/.github/skills/workshop-testing/SKILL.md
+++ b/.github/skills/workshop-testing/SKILL.md
@@ -27,7 +27,7 @@ docker --version                                    # only needed for Parts 4 an
 
 The script collects the `WORKSHOP_*` variables and, with `-ApplyUserSecrets`, writes the Foundry endpoint and key into the snapshot console projects (as `AzureOpenAI:Endpoint` / `AzureOpenAI:Key`), the local model settings into Part 9 if configured, and the composed `ConnectionStrings:openai` into the Part 11 AppHost. Add `-Force` if a key has been rotated since the last run.
 
-Nothing in the workshop reads `WORKSHOP_*` directly. The console samples read user secrets (`AzureOpenAI:Endpoint`, `AzureOpenAI:Key`) and the Aspire app reads `ConnectionStrings:openai`. **Projects you scaffold yourself during a test run still need their secrets set by hand** — the script only knows about the committed snapshots.
+Nothing in the workshop reads `WORKSHOP_*` directly. The console samples read user secrets (`AzureOpenAI:Endpoint`, `AzureOpenAI:Key`) and the Aspire app reads `ConnectionStrings:openai`. The script also configures a Part 4 app scaffolded at `test-workspace/GenAiLab`.
 
 The samples hardcode the deployment names `gpt-5-mini` and `text-embedding-3-small`. If the test resource uses different names, that is a source edit in every part, not a config change.
 

--- a/Part 11 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 11 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
+    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="13.4.6-preview.1.26319.6" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.DataIngestion" Version="10.7.0-preview.1.26309.5" />

--- a/Part 11 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
+++ b/Part 11 - Deployment/GenAiLab/GenAiLab.Web/GenAiLab.Web.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="13.4.6-preview.1.26319.6" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.0-preview.1.25474.7" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.DataIngestion" Version="10.7.0-preview.1.26309.5" />

--- a/Part 11 - Deployment/GenAiLab/README.md
+++ b/Part 11 - Deployment/GenAiLab/README.md
@@ -62,8 +62,9 @@ Note: Qdrant and Docker are excellent open source products, but are not maintain
 
 1. Open the project folder in Visual Studio Code.
 2. Install the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) for Visual Studio Code.
-3. Once installed, Open the `Program.cs` file in the GenAiLab.AppHost project.
-4. Run the project by clicking the "Run" button in the Debug view.
+3. Launch the `GenAiLab.AppHost` project (not just `GenAiLab.Web`) so Aspire starts all dependent services.
+4. Once installed, open the `AppHost.cs` file in the `GenAiLab.AppHost` project.
+5. Run the project by clicking the "Run" button in the Debug view.
 
 ## Trust the localhost certificate
 

--- a/Part 11 - Deployment/README.md
+++ b/Part 11 - Deployment/README.md
@@ -84,7 +84,7 @@ in Part 4 — remove the stale container and volume, then run again.
 > [!IMPORTANT]
 > **Vector Database Configuration**: This deployment uses **Qdrant** as the vector database, which runs as a containerized service in Azure Container Apps. No additional vector database setup is required.
 >
-> For a note on using a managed vector store in production, see [Optional: using a managed vector store](#optional-using-a-managed-vector-store) at the end of this part.
+> If you want a managed vector store for production later, Azure AI Search is an optional alternative. That is separate from the Qdrant-based walkthrough in this part, so no Azure AI Search resources are required to complete the steps below. See [Optional: using a managed vector store](#optional-using-a-managed-vector-store) at the end of this part for the high-level swap.
 
 1. Ensure you are in the root directory which contains the solution file.
 


### PR DESCRIPTION
## Summary

- Update the workshop credential setup script so it also handles scaffolded GenAiLab apps created during testing.
- Correct the Part 11 deployment instructions to reference AppHost.cs and describe the Qdrant-backed setup.
- Align the Part 11 web project package references with the workshop’s expected Azure OpenAI version.

## Notes

These changes address the documentation and package-version inconsistencies previously identified for the workshop snapshots.