### PR TITLE
Fix stale StoreApp references from pre-eShopLite Part 9 layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       - "/Part 05 - MCP Server Basics/MyMcpServer/"
       - "/Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/"
       - "/Part 08 - Agent Framework Basics/AgentApp/"
-      - "/Part 09 - Adding AI to an Existing App/StoreApp/"
+      - "/Part 09 - Adding AI to an Existing App/eShopLite-start/"
+      - "/Part 09 - Adding AI to an Existing App/eShopLite/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/skills/workshop-testing/SKILL.md
+++ b/.github/skills/workshop-testing/SKILL.md
@@ -43,7 +43,7 @@ The samples hardcode the deployment names `gpt-5-mini` and `text-embedding-3-sma
 | 6 - Enhanced MCP Server *(bonus)* | Exploration only — build and run the existing snapshot, review the README's business-integration guidance | `Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/` |
 | 7 - MCP Publishing *(bonus)* | Documentation review only. **Do not publish anything** | — |
 | 8 - Agent Framework Basics | `dotnet new console` → `AgentApp`, add `Microsoft.Agents.AI` per README. Verify the agent runs and can call the Part 5 weather tool if the README wires that up | `Part 08 - Agent Framework Basics/AgentApp/` |
-| 9 - Adding AI to an Existing App | Run the completed `StoreApp` snapshot. The local-inference module needs `LocalModel:Endpoint` / `LocalModel:Model` (Ollama or Foundry Local) — note it as skipped if unavailable | `Part 09 - Adding AI to an Existing App/StoreApp/` |
+| 9 - Adding AI to an Existing App | Follow the README in `eShopLite-start/`, then reconcile against the `eShopLite/` answer key. The optional local-model step needs `LocalModel:Endpoint` / `LocalModel:Model` (Foundry Local or Ollama) in the `Store` project — note it as skipped if unavailable | `Part 09 - Adding AI to an Existing App/eShopLite/` (answer key); `Part 09 - Adding AI to an Existing App/eShopLite-start/` |
 | 10 - Choosing Providers and Services | Documentation only — read for accuracy of provider names, packages, and config keys | — |
 | 11 - Deployment | See below | `Part 11 - Deployment/GenAiLab/` |
 

--- a/.github/skills/workshop-testing/report-template.md
+++ b/.github/skills/workshop-testing/report-template.md
@@ -47,7 +47,8 @@ Repeat per part that had anything worth saying.
 | `Part 05 - MCP Server Basics/MyMcpServer/` | | |
 | `Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/` | | |
 | `Part 08 - Agent Framework Basics/AgentApp/` | | |
-| `Part 09 - Adding AI to an Existing App/StoreApp/` | | |
+| `Part 09 - Adding AI to an Existing App/eShopLite/` | | |
+| `Part 09 - Adding AI to an Existing App/eShopLite-start/` | | |
 | `Part 11 - Deployment/GenAiLab/` | | |
 
 ## Issues


### PR DESCRIPTION
Part 9 is now the `eShopLite/` + `eShopLite-start/` Aspire solutions, but three files still referenced the removed `StoreApp/` console snapshot:

- **`.github/dependabot.yml`** — its NuGet `directories` list pointed at `/Part 09 - Adding AI to an Existing App/StoreApp/`, which no longer exists. Dependabot fails on that entry and Part 9's ten projects (two 5-project solutions) get no update coverage. Replaced with the `eShopLite-start/` and `eShopLite/` directories.
- **`.github/skills/workshop-testing/SKILL.md`** — the part-by-part table told testers to "run the completed `StoreApp` snapshot". Now describes the actual flow (work in `eShopLite-start/`, reconcile against the `eShopLite/` answer key, optional `LocalModel:*` secrets in the `Store` project).
- **`.github/skills/workshop-testing/report-template.md`** — snapshot reconciliation table now lists both Part 9 solutions.

The July 2026 test report (`docs/testing/workshop-test-report-2026-07-27.md`) flagged the SKILL.md issue; this resolves it. Markdownlint passes on both edited markdown files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>